### PR TITLE
냉장고를부탁해#8 레시피카드 컴포넌트 작성

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -56,6 +56,8 @@ module.exports = {
     'react/prop-types': 'off',
     'react/require-default-props': 'off',
     'react/jsx-props-no-spreading': 'off',
+    // TODO: Mock데이터 완성후엔 no-array-index-key : off 옵션 삭제
+    'react/no-array-index-key': 'off',
     'react/function-component-definition': [
       'error',
       {

--- a/src/components/common/LargeRecipeCard.tsx
+++ b/src/components/common/LargeRecipeCard.tsx
@@ -1,0 +1,55 @@
+import { Chip, Card, CardActions, CardContent, CardMedia } from '@mui/material';
+import { styled } from 'styled-components';
+import {
+  MatchedFood,
+  type CardProps,
+  MatchedFoodList,
+  BriefExplanation,
+  RecipeTitle,
+} from './SmallRecipeCard';
+import { StyledLink } from '../layout/header/Header';
+
+export const LargeRecipeCard = ({
+  recipeTitle,
+  briefExplanation,
+  imageURL,
+  matchedFoodList,
+}: CardProps) => {
+  return (
+    <StyledLink to="/">
+      <StyledCard sx={{ maxWidth: 760, minHeight: 320 }}>
+        <CardMedia sx={{ minWidth: 260 }} image={imageURL} title="레시피 사진" />
+        <div>
+          <CardContent>
+            <RecipeTitle> {recipeTitle}</RecipeTitle>
+            <BriefExplanation>{briefExplanation}</BriefExplanation>
+          </CardContent>
+          <MatchedFoodList>
+            <MatchedFood>일치하는 재료</MatchedFood>
+            <CardActions>
+              {matchedFoodList.length !== 0 ? (
+                // TODO: key수정하기
+                matchedFoodList.map((food, index) => <Chip key={index} label={food} />)
+              ) : (
+                <p>일치하는 재료가 없습니다.</p>
+              )}
+            </CardActions>
+          </MatchedFoodList>
+        </div>
+      </StyledCard>
+    </StyledLink>
+  );
+};
+
+const StyledCard = styled(Card)`
+  display: flex;
+  min-height: 300px;
+
+  .css-gavykb-MuiChip-root {
+    margin-bottom: 10px;
+  }
+
+  .css-dnrpxu-MuiCardActions-root {
+    flex-wrap: wrap;
+  }
+`;

--- a/src/components/common/SmallRecipeCard.tsx
+++ b/src/components/common/SmallRecipeCard.tsx
@@ -1,7 +1,8 @@
 import { Chip, Card, CardActions, CardContent, CardMedia } from '@mui/material';
 import { styled } from 'styled-components';
+import { StyledLink } from '../layout/header/Header';
 
-interface SmallCarState {
+export interface CardProps {
   recipeTitle: string;
   briefExplanation: string;
   imageURL: string;
@@ -13,29 +14,32 @@ export const SmallRecipeCard = ({
   briefExplanation,
   imageURL,
   matchedFoodList,
-}: SmallCarState) => {
+}: CardProps) => {
   return (
-    <StyledCard sx={{ maxWidth: 345 }}>
-      <CardMedia sx={{ height: 190 }} image={imageURL} title="레시피 사진" />
-      <CardContent>
-        <RecipeTitle> {recipeTitle}</RecipeTitle>
-        <BriefExplanation>{briefExplanation}</BriefExplanation>
-      </CardContent>
-      <MatchedFoodList>
-        <MatchedFood>일치하는 재료</MatchedFood>
-        <CardActions>
-          {matchedFoodList.map((food, index) => (
-            <Chip key={index} label={food} />
-          ))}
-        </CardActions>
-      </MatchedFoodList>
-    </StyledCard>
+    <StyledLink to="/">
+      <StyledCard sx={{ maxWidth: 345, minHeight: 300, minWidth: 290 }}>
+        <CardMedia sx={{ height: 190 }} image={imageURL} title="레시피 사진" />
+        <CardContent>
+          <RecipeTitle> {recipeTitle}</RecipeTitle>
+          <BriefExplanation>{briefExplanation}</BriefExplanation>
+        </CardContent>
+        <MatchedFoodList>
+          <MatchedFood>일치하는 재료</MatchedFood>
+          <CardActions>
+            {matchedFoodList.length !== 0 ? (
+              // TODO: key수정하기
+              matchedFoodList.map((food, index) => <Chip key={index} label={food} />)
+            ) : (
+              <p>일치하는 재료가 없습니다.</p>
+            )}
+          </CardActions>
+        </MatchedFoodList>
+      </StyledCard>
+    </StyledLink>
   );
 };
 
 const StyledCard = styled(Card)`
-  min-height: 300px;
-  min-width: 290px;
   margin: 14px;
 
   .css-gavykb-MuiChip-root {
@@ -47,26 +51,26 @@ const StyledCard = styled(Card)`
   }
 `;
 
-const RecipeTitle = styled.h5`
+export const RecipeTitle = styled.h5`
   font-size: 20px;
   line-height: 30px;
   font-weight: 600;
 `;
 
-const BriefExplanation = styled.p`
+export const BriefExplanation = styled.p`
   color: ${(props) => props.theme.colors.darkGray};
   width: 100%;
   margin-top: 20px;
   line-height: 20px;
 `;
 
-const MatchedFood = styled.p`
+export const MatchedFood = styled.p`
   color: ${(props) => props.theme.colors.black};
   font-weight: 600;
   font-size: 14px;
   margin: 10px 0 5px 10px;
 `;
 
-const MatchedFoodList = styled.div`
+export const MatchedFoodList = styled.div`
   padding: 10px;
 `;

--- a/src/components/common/SmallRecipeCard.tsx
+++ b/src/components/common/SmallRecipeCard.tsx
@@ -1,0 +1,72 @@
+import { Chip, Card, CardActions, CardContent, CardMedia } from '@mui/material';
+import { styled } from 'styled-components';
+
+interface SmallCarState {
+  recipeTitle: string;
+  briefExplanation: string;
+  imageURL: string;
+  matchedFoodList: string[];
+}
+
+export const SmallRecipeCard = ({
+  recipeTitle,
+  briefExplanation,
+  imageURL,
+  matchedFoodList,
+}: SmallCarState) => {
+  return (
+    <StyledCard sx={{ maxWidth: 345 }}>
+      <CardMedia sx={{ height: 190 }} image={imageURL} title="레시피 사진" />
+      <CardContent>
+        <RecipeTitle> {recipeTitle}</RecipeTitle>
+        <BriefExplanation>{briefExplanation}</BriefExplanation>
+      </CardContent>
+      <MatchedFoodList>
+        <MatchedFood>일치하는 재료</MatchedFood>
+        <CardActions>
+          {matchedFoodList.map((food, index) => (
+            <Chip key={index} label={food} />
+          ))}
+        </CardActions>
+      </MatchedFoodList>
+    </StyledCard>
+  );
+};
+
+const StyledCard = styled(Card)`
+  min-height: 300px;
+  min-width: 290px;
+  margin: 14px;
+
+  .css-gavykb-MuiChip-root {
+    margin-bottom: 10px;
+  }
+
+  .css-dnrpxu-MuiCardActions-root {
+    flex-wrap: wrap;
+  }
+`;
+
+const RecipeTitle = styled.h5`
+  font-size: 20px;
+  line-height: 30px;
+  font-weight: 600;
+`;
+
+const BriefExplanation = styled.p`
+  color: ${(props) => props.theme.colors.darkGray};
+  width: 100%;
+  margin-top: 20px;
+  line-height: 20px;
+`;
+
+const MatchedFood = styled.p`
+  color: ${(props) => props.theme.colors.black};
+  font-weight: 600;
+  font-size: 14px;
+  margin: 10px 0 5px 10px;
+`;
+
+const MatchedFoodList = styled.div`
+  padding: 10px;
+`;

--- a/src/components/layout/Index.tsx
+++ b/src/components/layout/Index.tsx
@@ -7,9 +7,9 @@ export const Index = () => {
         {/** TODO: 이곳에 타이틀 컴포넌트 추가 */}타이틀<MoreButton>더보기</MoreButton>
       </Title>
       <SamllCardList>
-        {[1, 2, 3, 4, 5, 6].map(() => (
+        {[1, 2, 3, 4, 5, 6].map((_, index) => (
           // TODO: 이곳에 smallCard 컴포넌트 추가, 아래는 임시 컴포넌트
-          <ExampleCard></ExampleCard>
+          <ExampleCard key={index}></ExampleCard>
         ))}
       </SamllCardList>
       <Title>

--- a/src/components/layout/Index.tsx
+++ b/src/components/layout/Index.tsx
@@ -14,7 +14,7 @@ export const Index = () => {
             recipeTitle="레시피 제목"
             briefExplanation="간단 설명 You can add ornaments to the beginning of the component."
             imageURL="/"
-            matchedFoodList={['양파', '무', '당근']}
+            matchedFoodList={['당근', '무']}
           />
         ))}
       </SamllCardList>

--- a/src/components/layout/Index.tsx
+++ b/src/components/layout/Index.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { SmallRecipeCard } from '../common/SmallRecipeCard';
 
 export const Index = () => {
   return (
@@ -7,9 +8,14 @@ export const Index = () => {
         {/** TODO: 이곳에 타이틀 컴포넌트 추가 */}타이틀<MoreButton>더보기</MoreButton>
       </Title>
       <SamllCardList>
-        {[1, 2, 3, 4, 5, 6].map((_, index) => (
-          // TODO: 이곳에 smallCard 컴포넌트 추가, 아래는 임시 컴포넌트
-          <ExampleCard key={index}></ExampleCard>
+        {[1, 2, 3, 4, 5].map((_, index) => (
+          <SmallRecipeCard
+            key={index}
+            recipeTitle="레시피 제목"
+            briefExplanation="간단 설명 You can add ornaments to the beginning of the component."
+            imageURL="/"
+            matchedFoodList={['양파', '무', '당근']}
+          />
         ))}
       </SamllCardList>
       <Title>
@@ -50,6 +56,10 @@ const SamllCardList = styled.section`
   overflow-y: clip;
   align-items: flex-start;
   margin-bottom: 80px;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const ExampleCard = styled.div`

--- a/src/components/layout/Index.tsx
+++ b/src/components/layout/Index.tsx
@@ -58,7 +58,17 @@ const SamllCardList = styled.section`
   margin-bottom: 80px;
 
   &::-webkit-scrollbar {
-    display: none;
+    height: 8px;
+    background-color: ${(props) => props.theme.colors.lightGray};
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: ${(props) => props.theme.colors.gray};
+    border-radius: 8px;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background-color: ${(props) => props.theme.colors.darkGray};
   }
 `;
 

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -38,7 +38,7 @@ const TempInput = styled.input`
   width: 70%;
 `;
 
-const StyledLink = styled(Link)`
+export const StyledLink = styled(Link)`
   text-decoration: none;
   color: inherit;
 `;


### PR DESCRIPTION
## 레시피 카드 컴포넌트 작성 (samll & large)

### 작업내용
![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/107461545/3f36569f-3f6d-468e-98f3-e9f8c7d7c3c9)
![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/107461545/c5ffde20-1fe8-43be-a350-69a8c60f2638)


- 레시피 카드 컴포넌트 (samll & large)를 props를 받아 사용할 수 있도록 만들었습니다.
- 컴포넌트의 공백은 사진이 들어갈 자리 입니다.  (small기준 위쪽, large기준 왼쪽)
- 디자인이 단조롭습니다. 스크롤바를 꾸며봤지만 여전히 단조롭습니다.