### PR TITLE
냉장고를 부탁해 #23 단계별 레시피 사진&내용 입력 폼 생성, 재료 리스트 버튼 공통컴포넌트로 추가

### DIFF
--- a/src/components/IngredientSearchForm.tsx
+++ b/src/components/IngredientSearchForm.tsx
@@ -1,0 +1,75 @@
+import { Chip, InputAdornment, TextField } from '@mui/material';
+import type { ChangeEvent } from 'react';
+import { styled } from 'styled-components';
+import { BasicButton } from './common/BasicButton';
+import { theme } from '../styles/theme';
+import { useIngredient } from '../hooks/useIngredient';
+
+export const IngredientSearchForm = () => {
+  const { query, setQuery, visible, selectedItem, handleSelect, handleDelete, addIngredient } =
+    useIngredient();
+
+  return (
+    <Form onSubmit={addIngredient}>
+      <SearchWrapper>
+        <TextField
+          value={query}
+          onChange={(event: ChangeEvent<HTMLInputElement>) => setQuery(event.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                {selectedItem.map((item, index) => (
+                  <Chip
+                    style={{ marginRight: '4px' }}
+                    key={index}
+                    label={item}
+                    onDelete={() => handleDelete(index)}
+                  />
+                ))}
+              </InputAdornment>
+            ),
+          }}
+        />
+        <BasicButton type="submit" $bgcolor={theme.colors.orange} $fontcolor={theme.colors.white}>
+          +
+        </BasicButton>
+      </SearchWrapper>
+      {visible && (
+        <SearchedList>
+          {new Array(5).fill(1).map((_, i) => (
+            <SearchedItem key={i} onClick={handleSelect}>
+              <p>당근</p>
+            </SearchedItem>
+          ))}
+        </SearchedList>
+      )}
+    </Form>
+  );
+};
+
+const Form = styled.form`
+  position: relative;
+`;
+
+const SearchWrapper = styled.div`
+  display: grid;
+  grid-template-columns: 97% 50px;
+  gap: 15px;
+  margin-top: 40px;
+`;
+
+const SearchedList = styled.ul`
+  display: grid;
+  position: absolute;
+  width: 97%;
+  height: 300px;
+`;
+
+const SearchedItem = styled.li`
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  padding: 10px;
+  background-color: ${(props) => props.theme.colors.grayishWhite};
+  border: 1px solid ${(props) => props.theme.colors.lightGray};
+`;

--- a/src/components/IngredientSearchForm.tsx
+++ b/src/components/IngredientSearchForm.tsx
@@ -53,7 +53,7 @@ const Form = styled.form`
 
 const SearchWrapper = styled.div`
   display: grid;
-  grid-template-columns: 97% 50px;
+  grid-template-columns: 90% 10%;
   gap: 15px;
   margin-top: 40px;
 `;
@@ -61,7 +61,7 @@ const SearchWrapper = styled.div`
 const SearchedList = styled.ul`
   display: grid;
   position: absolute;
-  width: 97%;
+  width: 90%;
   height: 300px;
 `;
 

--- a/src/components/RecipeStep.tsx
+++ b/src/components/RecipeStep.tsx
@@ -1,0 +1,132 @@
+import { styled } from 'styled-components';
+import { BasicButton } from './common/BasicButton';
+import { theme } from '../styles/theme';
+import { type ChangeEvent } from 'react';
+
+type stepProps = {
+  image: string;
+  index: number;
+  deleteStep: (index: number) => void;
+  handleImageStep: (event: ChangeEvent<HTMLInputElement>, index: number) => void;
+  handleContentStep: (event: ChangeEvent<HTMLTextAreaElement>, index: number) => void;
+  deleteImageStep: (index: number) => void;
+};
+
+export const RecipeStep = ({
+  image,
+  index,
+  deleteStep,
+  handleImageStep,
+  handleContentStep,
+  deleteImageStep,
+}: stepProps) => {
+  return (
+    <>
+      <DeleteButton>
+        <BasicButton
+          type="button"
+          $bgcolor={theme.colors.orange}
+          $fontcolor={theme.colors.white}
+          clickFn={() => deleteStep(index)}
+        >
+          단계 삭제
+        </BasicButton>
+      </DeleteButton>
+      <RecipeContainer>
+        <div>
+          {image && image ? (
+            <>
+              <UploadImage src={image} alt="업로드된 이미지" />
+              <ButtonWrapper>
+                <BasicButton
+                  type="button"
+                  $bgcolor={theme.colors.orange}
+                  $fontcolor={theme.colors.white}
+                  clickFn={() => deleteImageStep(index)}
+                >
+                  사진 삭제
+                </BasicButton>
+              </ButtonWrapper>
+            </>
+          ) : (
+            <>
+              <TempImage>
+                <p>이미지</p>
+              </TempImage>
+              <FileInput
+                type="file"
+                id="file"
+                accept="image/*"
+                onChange={(event) => handleImageStep(event, index)}
+              />
+              <FileLabel htmlFor="file">
+                <p>사진추가</p>
+              </FileLabel>
+            </>
+          )}
+        </div>
+        <Content onChange={(event) => handleContentStep(event, index)}></Content>
+      </RecipeContainer>
+    </>
+  );
+};
+
+const RecipeContainer = styled.div`
+  display: flex;
+  margin-top: 20px;
+  margin-bottom: 20px;
+`;
+
+const DeleteButton = styled.div`
+  display: grid;
+  justify-content: end;
+`;
+
+const UploadImage = styled.img`
+  width: 200px;
+  height: 200px;
+  margin-bottom: 10px;
+`;
+
+const TempImage = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 10px;
+  width: 200px;
+  height: 200px;
+  background-color: ${(props) => props.theme.colors.gray};
+`;
+
+const FileInput = styled.input`
+  display: none;
+`;
+
+const ButtonWrapper = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+`;
+
+const FileLabel = styled.label`
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  padding: 10px 20px;
+  background-color: ${(props) => props.theme.colors.orange};
+  color: white;
+  cursor: pointer;
+  margin-right: 5px;
+`;
+
+const Content = styled.textarea`
+  width: 90%;
+  height: 200px;
+  margin-left: 20px;
+  border-radius: 10px;
+  padding: 12px;
+  font-size: 18px;
+  border: 1px solid ${(props) => props.theme.colors.gray};
+  resize: none;
+`;

--- a/src/components/common/BasicButton.tsx
+++ b/src/components/common/BasicButton.tsx
@@ -3,7 +3,8 @@ import styled from 'styled-components';
 interface BasicButtonProps {
   children: React.ReactNode;
   type: string;
-  clickFn?: () => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  clickFn?: (param?: any) => void;
   $bgcolor: string;
   $hoverbgcolor?: string;
   $fontcolor?: string;

--- a/src/components/common/BasicButton.tsx
+++ b/src/components/common/BasicButton.tsx
@@ -3,27 +3,30 @@ import styled from 'styled-components';
 interface BasicButtonProps {
   children: React.ReactNode;
   type: string;
-  bgcolor: string;
-  hoverbgcolor?: string;
-  fontcolor?: string;
-  bordercolor?: string;
+  clickFn?: () => void;
+  $bgcolor: string;
+  $hoverbgcolor?: string;
+  $fontcolor?: string;
+  $bordercolor?: string;
 }
 
 export const BasicButton = ({
   children,
   type,
-  bgcolor,
-  hoverbgcolor,
-  fontcolor = '#000',
-  bordercolor,
+  clickFn,
+  $bgcolor,
+  $hoverbgcolor,
+  $fontcolor = '#000',
+  $bordercolor,
 }: BasicButtonProps) => {
   return (
     <BasicButtonWrap
       type={type}
-      bgcolor={bgcolor}
-      hoverbgcolor={hoverbgcolor}
-      fontcolor={fontcolor}
-      bordercolor={bordercolor}
+      onClick={clickFn}
+      $bgcolor={$bgcolor}
+      $hoverbgcolor={$hoverbgcolor}
+      $fontcolor={$fontcolor}
+      $bordercolor={$bordercolor}
     >
       {children}
     </BasicButtonWrap>
@@ -33,15 +36,15 @@ export const BasicButton = ({
 const BasicButtonWrap = styled.button<BasicButtonProps>`
   width: 100%;
   font-size: 14px;
-  color: ${(props) => props.fontcolor};
-  background-color: ${(props) => props.bgcolor};
-  border: 1px solid ${(props) => (props.bordercolor ? props.bordercolor : props.bgcolor)};
+  color: ${(props) => props.$fontcolor};
+  background-color: ${(props) => props.$bgcolor};
+  border: 1px solid ${(props) => (props.$bordercolor ? props.$bordercolor : props.$bgcolor)};
   padding: 12px 6px;
   border-radius: 8px;
   transition: all 0.3s;
   cursor: pointer;
 
   &:hover {
-    background-color: ${(props) => props.hoverbgcolor};
+    background-color: ${(props) => props.$hoverbgcolor};
   }
 `;

--- a/src/components/common/BasicInput.tsx
+++ b/src/components/common/BasicInput.tsx
@@ -4,10 +4,20 @@ interface BasicInputProps {
   id?: string;
   type: string;
   placeholder?: string;
+  onChange?: () => void;
+  value?: string;
 }
 
-export const BasicInput = ({ id, type, placeholder }: BasicInputProps) => {
-  return <BasicInputWrap id={id} type={type} placeholder={placeholder}></BasicInputWrap>;
+export const BasicInput = ({ id, type, placeholder, onChange, value }: BasicInputProps) => {
+  return (
+    <BasicInputWrap
+      id={id}
+      type={type}
+      placeholder={placeholder}
+      onChange={onChange}
+      value={value}
+    ></BasicInputWrap>
+  );
 };
 
 const BasicInputWrap = styled.input`

--- a/src/components/common/IngredientList.tsx
+++ b/src/components/common/IngredientList.tsx
@@ -1,0 +1,37 @@
+import { Chip, Stack } from '@mui/material';
+import { useState } from 'react';
+import { styled } from 'styled-components';
+
+interface IngredientListProps {
+  titleList?: string[];
+}
+
+export const IngredientList = ({ titleList }: IngredientListProps) => {
+  // 추후 재료의 길이만큼 뱃지 배열 설정
+  const [selected, setSelected] = useState(Array(4).fill(false));
+
+  const handleClick = (index: number) => {
+    const newSelected = [...selected];
+    newSelected[index] = !newSelected[index];
+    setSelected(newSelected);
+  };
+
+  return (
+    <ListWrapper>
+      <Stack direction="row" spacing={1}>
+        {titleList?.map((title, i) => (
+          <Chip
+            color={selected[i] ? 'warning' : 'default'}
+            key={i}
+            label={title}
+            onClick={() => handleClick(i)}
+          />
+        ))}
+      </Stack>
+    </ListWrapper>
+  );
+};
+
+const ListWrapper = styled.div`
+  margin-top: 20px;
+`;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -10,9 +10,10 @@ import { currentCategoryAtom } from '../../store/menu';
 
 export const Header = () => {
   const [sidBar, setSidBar] = useState(false);
-  
+
   const navigation = useNavigate();
   const setCurrentCategory = useSetRecoilState(currentCategoryAtom);
+
   const handleLogin = () => {
     navigation('/signin');
     setCurrentCategory('');
@@ -22,9 +23,15 @@ export const Header = () => {
     <Container>
       <Wrapper>
         <BasicInput id="text" type="email" placeholder="재료, 레시피를 검색해 주세요." />
-          <BasicButton onClick={handleLogin} type="button" bgcolor="#FF8527" fontcolor="#fff" hoverbgcolor="#ff750c">
-            로그인
-          </BasicButton>
+        <BasicButton
+          clickFn={handleLogin}
+          type="button"
+          $bgcolor="#FF8527"
+          $fontcolor="#fff"
+          $hoverbgcolor="#ff750c"
+        >
+          로그인
+        </BasicButton>
         <StyledSvg
           xmlns="http://www.w3.org/2000/svg"
           width="16"
@@ -54,14 +61,12 @@ const Container = styled.header`
 `;
 
 const Wrapper = styled.div`
-
   display: grid;
   grid-template-columns: 70% 1fr 1fr;
   gap: 12px;
   width: 768px;
   margin: 0 auto;
 `;
-
 
 export const StyledLink = styled(Link)`
   text-decoration: none;

--- a/src/components/pages/myPage/NicknameEdit.tsx
+++ b/src/components/pages/myPage/NicknameEdit.tsx
@@ -9,7 +9,7 @@ export const NicknameEdit = () => {
       <BasicInput id="nickname" type="text" placeholder="변경할 닉네임을 입력하세요" />
       <p className="error">이미 존재하는 닉네임 입니다.</p>
       <br />
-      <BasicButton bgcolor="#ff8527" type="text" fontcolor="#fff">
+      <BasicButton $bgcolor="#ff8527" type="text" $fontcolor="#fff">
         변경하기
       </BasicButton>
     </NicknameEditContainer>

--- a/src/components/pages/myPage/PasswordEdit.tsx
+++ b/src/components/pages/myPage/PasswordEdit.tsx
@@ -14,7 +14,7 @@ export const PasswordEdit = () => {
         type="password"
         placeholder="변경할 비밀번호를 한번 더 입력하세요"
       />
-      <BasicButton bgcolor="#ff8527" type="text" fontcolor="#fff">
+      <BasicButton $bgcolor="#ff8527" type="text" $fontcolor="#fff">
         변경하기
       </BasicButton>
     </PasswordEditContainer>

--- a/src/hooks/useIngredient.ts
+++ b/src/hooks/useIngredient.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+
+export const useIngredient = (initialQuery = '') => {
+  const [query, setQuery] = useState(initialQuery);
+  const [visible, setVisible] = useState(false);
+  const [selectedItem, setSelectedItem] = useState<string[]>([]);
+
+  useEffect(() => {
+    setVisible(query !== '');
+  }, [query]);
+
+  const handleSelect = (event: React.MouseEvent<HTMLElement>) => {
+    const target = event.target as HTMLElement;
+    setSelectedItem([...selectedItem, target.innerText]);
+    setQuery('');
+    setVisible(false);
+  };
+
+  const handleDelete = (deleteIndex: number) => {
+    setSelectedItem(selectedItem.filter((_, index) => index !== deleteIndex));
+  };
+
+  const addIngredient = (event: React.FormEvent) => {
+    event.preventDefault();
+  };
+
+  return { query, setQuery, visible, selectedItem, handleSelect, handleDelete, addIngredient };
+};

--- a/src/pages/AddRecipe.tsx
+++ b/src/pages/AddRecipe.tsx
@@ -4,8 +4,62 @@ import { BasicButton } from '../components/common/BasicButton';
 import { BasicTitle } from '../components/common/BasicTitle';
 import { theme } from '../styles/theme';
 import { IngredientSearchForm } from '../components/IngredientSearchForm';
+import { RecipeStep } from '../components/RecipeStep';
+import { useState, type ChangeEvent } from 'react';
+
+type Step = {
+  image: string;
+  content: string;
+};
 
 export const AddRecipe = () => {
+  const [step, setStep] = useState<Step[]>([{ image: '', content: '' }]);
+  // console.log(step);
+
+  const handleImageStep = (event: ChangeEvent<HTMLInputElement>, index: number) => {
+    const newImage = [...step];
+    const file = event.target.files && event.target.files[0];
+    const reader = new FileReader();
+
+    reader.onloadend = () => {
+      newImage[index] = {
+        image: reader.result as string,
+        content: newImage[index].content,
+      };
+      setStep(newImage);
+    };
+
+    if (file) {
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleContentStep = (event: ChangeEvent<HTMLTextAreaElement>, index: number) => {
+    const newContent = [...step];
+    newContent[index] = {
+      image: newContent[index].image,
+      content: event.target.value,
+    };
+    setStep(newContent);
+  };
+
+  const deleteStep = (index: number) => {
+    setStep(step.filter((_, idx) => idx !== index));
+  };
+
+  const addStep = () => {
+    setStep([...step, { image: '', content: '' }]);
+  };
+
+  const deleteImageStep = (index: number) => {
+    const newStep = [...step];
+    newStep[index] = {
+      ...newStep[index],
+      image: '',
+    };
+    setStep(newStep);
+  };
+
   return (
     <>
       <TitleWrapper>
@@ -15,13 +69,64 @@ export const AddRecipe = () => {
         </BasicButton>
         <IngredientSearchForm />
       </TitleWrapper>
-
       <IngredientList titleList={['당근', '무', '오징어']} />
+      <WriteContainer>
+        <RecipeTitle placeholder="레시피 제목 입력" />
+        {step.map((e, i) => (
+          <RecipeStep
+            key={i}
+            index={i}
+            image={e.image}
+            deleteStep={deleteStep}
+            deleteImageStep={deleteImageStep}
+            handleImageStep={handleImageStep}
+            handleContentStep={handleContentStep}
+          />
+        ))}
+        <BasicButton
+          type="button"
+          $bgcolor={theme.colors.orange}
+          $fontcolor={theme.colors.white}
+          clickFn={addStep}
+        >
+          +
+        </BasicButton>
+        <ButtonWrapper>
+          <BasicButton type="submit" $bgcolor={theme.colors.orange} $fontcolor={theme.colors.white}>
+            완료
+          </BasicButton>
+          <BasicButton type="button" $bgcolor={theme.colors.orange} $fontcolor={theme.colors.white}>
+            돌아가기
+          </BasicButton>
+        </ButtonWrapper>
+      </WriteContainer>
     </>
   );
 };
 
 const TitleWrapper = styled.div`
   display: grid;
-  grid-template-columns: 90% 50px;
+  grid-template-columns: 90% 10%;
+`;
+
+const WriteContainer = styled.form`
+  display: grid;
+  grid-template-columns: 100%;
+  margin-top: 50px;
+`;
+
+const RecipeTitle = styled.input`
+  height: 50px;
+  border: none;
+  font-size: 24px;
+  padding-left: 10px;
+  outline: none;
+`;
+
+const ButtonWrapper = styled.div`
+  display: grid;
+  grid-template-columns: 200px 200px;
+  gap: 4px;
+  margin-top: 40px;
+  justify-content: end;
 `;

--- a/src/pages/AddRecipe.tsx
+++ b/src/pages/AddRecipe.tsx
@@ -1,0 +1,27 @@
+import { styled } from 'styled-components';
+import { IngredientList } from '../components/common/IngredientList';
+import { BasicButton } from '../components/common/BasicButton';
+import { BasicTitle } from '../components/common/BasicTitle';
+import { theme } from '../styles/theme';
+import { IngredientSearchForm } from '../components/IngredientSearchForm';
+
+export const AddRecipe = () => {
+  return (
+    <>
+      <TitleWrapper>
+        <BasicTitle title="어떤 재료를 사용할까요?" />
+        <BasicButton type="button" $bgcolor={theme.colors.orange} $fontcolor={theme.colors.white}>
+          삭제
+        </BasicButton>
+        <IngredientSearchForm />
+      </TitleWrapper>
+
+      <IngredientList titleList={['당근', '무', '오징어']} />
+    </>
+  );
+};
+
+const TitleWrapper = styled.div`
+  display: grid;
+  grid-template-columns: 90% 50px;
+`;

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -18,19 +18,24 @@ export const SignIn = () => {
           <BasicInput id="pw" type="password" placeholder="비밀번호를 입력해 주세요" />
         </div>
         <div className="buttons">
-          <BasicButton type="submit" bgcolor="#FF8527" fontcolor="#fff" hoverbgcolor="#ff750c">
+          <BasicButton type="submit" $bgcolor="#FF8527" $fontcolor="#fff" $hoverbgcolor="#ff750c">
             이메일 로그인
           </BasicButton>
 
           <div className="line-text">간편 로그인</div>
 
-          <BasicButton type="button" bgcolor="#fff" hoverbgcolor="#ececec" bordercolor="#c0c0c0">
+          <BasicButton type="button" $bgcolor="#fff" $hoverbgcolor="#ececec" $bordercolor="#c0c0c0">
             <div className="icon-button">
               <FcGoogle />
               구글 계정으로 로그인
             </div>
           </BasicButton>
-          <BasicButton type="button" bgcolor="#FEE502" hoverbgcolor="#ffe100" bordercolor="#ffe100">
+          <BasicButton
+            type="button"
+            $bgcolor="#FEE502"
+            $hoverbgcolor="#ffe100"
+            $bordercolor="#ffe100"
+          >
             <div className="icon-button">
               <HiMiniChatBubbleOvalLeft />
               카카오 로그인

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -23,7 +23,7 @@ export const SignUp = () => {
           <label htmlFor="nickname">닉네임</label>
           <BasicInput id="nickname" type="text" placeholder="사용할 닉네임을 입력하세요" />
         </div>
-        <BasicButton type="submit" bgcolor="#FF8527" fontcolor="#fff" hoverbgcolor="#ff750c">
+        <BasicButton type="submit" $bgcolor="#FF8527" $fontcolor="#fff" $hoverbgcolor="#ff750c">
           회원 가입
         </BasicButton>
         <Link to="/signin">

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -3,11 +3,14 @@ import { Index } from '../pages/Index';
 import { SignIn } from '../pages/SignIn';
 import { SignUp } from '../pages/SignUp';
 import { MyPage } from '../pages/MyPage';
+import { AddRecipe } from '../pages/AddRecipe';
 
 export const Router = () => {
   return (
     <Routes>
       <Route index element={<Index />} />
+      {/** add/ => 화면 테스트용 임시 라우팅 */}
+      <Route path="/add" element={<AddRecipe />} />
       <Route path="/signin" element={<SignIn />} />
       <Route path="/signup" element={<SignUp />} />
       <Route path="/mypage" element={<MyPage />} />


### PR DESCRIPTION
![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/107461545/19765cc1-71af-4170-863c-a738059d2c4d)
![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/107461545/312cab84-e738-49c9-8e69-b4072b79742d)

- 단계별 레시피 사진&내용 입력 폼을 생성하고 재료 리스트 버튼 공통컴포넌트로 추가하였습니다.
- 스타일드 컴포넌트 props 경고를 해결하였습니다.
- basicInput과 BasicButton에 props를 추가하였습니다.
- 초반에 자료구조를 잘못 생각해 시간을 많이 잡아먹었습니다.