### PR TITLE
냉장고를 부탁해 #32 레시피 등록 페이지 재료검색 및 등록 플로우 수정

### DIFF
--- a/src/components/IngredientSearchForm.tsx
+++ b/src/components/IngredientSearchForm.tsx
@@ -2,49 +2,88 @@ import { Chip, InputAdornment, TextField } from '@mui/material';
 import type { ChangeEvent } from 'react';
 import { styled } from 'styled-components';
 import { BasicButton } from './common/BasicButton';
+import { IngredientList } from './common/IngredientList';
 import { theme } from '../styles/theme';
-import { useIngredient } from '../hooks/useIngredient';
 import { device } from '../styles/media';
+import { useIngredient } from '../hooks/useIngredient';
 
-export const IngredientSearchForm = () => {
-  const { query, setQuery, visible, selectedItem, handleSelect, handleDelete, addIngredient } =
-    useIngredient();
+interface SearchFormPorps {
+  selectedItem: string[];
+  setSelectedItem: React.Dispatch<React.SetStateAction<string[]>>;
+  isRecipePageSearch: boolean;
+}
+
+export const IngredientSearchForm = ({
+  selectedItem,
+  setSelectedItem,
+  isRecipePageSearch,
+}: SearchFormPorps) => {
+  const {
+    addItemList,
+    query,
+    visible,
+    selectedQuery,
+    handleSelect,
+    handleDelete,
+    addIngredient,
+    handleItemList,
+    setQuery,
+  } = useIngredient();
 
   return (
-    <Form onSubmit={addIngredient}>
-      <SearchWrapper>
-        <TextField
-          value={query}
-          onChange={(event: ChangeEvent<HTMLInputElement>) => setQuery(event.target.value)}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                {selectedItem.map((item, index) => (
-                  <Chip
-                    style={{ marginRight: '4px' }}
-                    key={index}
-                    label={item}
-                    onDelete={() => handleDelete(index)}
-                  />
-                ))}
-              </InputAdornment>
-            ),
-          }}
+    <>
+      <Form onSubmit={(e) => addIngredient(e, isRecipePageSearch)}>
+        <SearchWrapper>
+          <TextField
+            value={query}
+            onChange={(event: ChangeEvent<HTMLInputElement>) => setQuery(event.target.value)}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  {selectedQuery.map((item, index) => (
+                    <Chip
+                      style={{ marginRight: '4px' }}
+                      key={index}
+                      label={item}
+                      onDelete={() => handleDelete(index)}
+                    />
+                  ))}
+                </InputAdornment>
+              ),
+            }}
+          />
+          <BasicButton
+            type={isRecipePageSearch ? 'button' : 'submit'}
+            $bgcolor={theme.colors.orange}
+            $fontcolor={theme.colors.white}
+            onClick={isRecipePageSearch ? handleItemList : undefined}
+          >
+            +
+          </BasicButton>
+        </SearchWrapper>
+        {visible && (
+          <SearchedList>
+            {new Array(5).fill(1).map((_, i) => (
+              <SearchedItem key={i} onClick={handleSelect}>
+                <p>당근</p>
+              </SearchedItem>
+            ))}
+          </SearchedList>
+        )}
+      </Form>
+      <IngredientList
+        setSelectedIngredient={setSelectedItem}
+        usedIngredient={selectedItem}
+        titleList={['원래 냉장고 재료']}
+      />
+      {isRecipePageSearch && (
+        <IngredientList
+          setSelectedIngredient={setSelectedItem}
+          usedIngredient={selectedItem}
+          titleList={addItemList}
         />
-        <BasicButton type="submit" $bgcolor={theme.colors.orange} $fontcolor={theme.colors.white}>
-          +
-        </BasicButton>
-      </SearchWrapper>
-      {visible && (
-        <SearchedList>
-          {new Array(5).fill(1).map((_, i) => (
-            <SearchedItem key={i} onClick={handleSelect}>
-              <p>당근</p>
-            </SearchedItem>
-          ))}
-        </SearchedList>
       )}
-    </Form>
+    </>
   );
 };
 

--- a/src/hooks/useIngredient.ts
+++ b/src/hooks/useIngredient.ts
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react';
 
-export const useIngredient = (initialQuery = '') => {
-  const [query, setQuery] = useState(initialQuery);
+export const useIngredient = () => {
+  const [addItemList, setAddItemList] = useState<string[]>([]);
+  const [query, setQuery] = useState('');
   const [visible, setVisible] = useState(false);
-  const [selectedItem, setSelectedItem] = useState<string[]>([]);
+  const [selectedQuery, setSelectedQuery] = useState<string[]>([]);
 
   useEffect(() => {
     setVisible(query !== '');
@@ -11,18 +12,42 @@ export const useIngredient = (initialQuery = '') => {
 
   const handleSelect = (event: React.MouseEvent<HTMLElement>) => {
     const target = event.target as HTMLElement;
-    setSelectedItem([...selectedItem, target.innerText]);
+    setSelectedQuery([...selectedQuery, target.innerText]);
     setQuery('');
     setVisible(false);
   };
 
   const handleDelete = (deleteIndex: number) => {
-    setSelectedItem(selectedItem.filter((_, index) => index !== deleteIndex));
+    setSelectedQuery(selectedQuery.filter((_, index) => index !== deleteIndex));
   };
 
-  const addIngredient = (event: React.FormEvent) => {
+  const addIngredient = (event: React.FormEvent, isRecipePageSearch: boolean) => {
     event.preventDefault();
+    if (isRecipePageSearch) {
+      if (query && !selectedQuery.includes(query)) {
+        setSelectedQuery([...selectedQuery, query]);
+      }
+      setQuery('');
+    }
+    if (selectedQuery.length > 0) {
+      // console.log('사용자 냉장고에 재료 추가');
+    }
   };
 
-  return { query, setQuery, visible, selectedItem, handleSelect, handleDelete, addIngredient };
+  const handleItemList = () => {
+    setAddItemList([...addItemList, ...selectedQuery]);
+    setSelectedQuery([]);
+  };
+
+  return {
+    addItemList,
+    query,
+    visible,
+    selectedQuery,
+    handleSelect,
+    handleDelete,
+    addIngredient,
+    handleItemList,
+    setQuery,
+  };
 };

--- a/src/pages/AddRecipe.tsx
+++ b/src/pages/AddRecipe.tsx
@@ -86,9 +86,6 @@ export const AddRecipe = () => {
     <>
       <TitleWrapper>
         <BasicTitle title="어떤 재료를 사용할까요?" />
-        <BasicButton type="button" $bgcolor={theme.colors.orange} $fontcolor={theme.colors.white}>
-          삭제
-        </BasicButton>
       </TitleWrapper>
       <IngredientSearchForm
         isRecipePageSearch

--- a/src/pages/AddRecipe.tsx
+++ b/src/pages/AddRecipe.tsx
@@ -1,12 +1,11 @@
 import { styled } from 'styled-components';
-import { IngredientList } from '../components/common/IngredientList';
 import { BasicButton } from '../components/common/BasicButton';
 import { BasicTitle } from '../components/common/BasicTitle';
 import { theme } from '../styles/theme';
-import { IngredientSearchForm } from '../components/IngredientSearchForm';
 import { RecipeStep } from '../components/RecipeStep';
 import { useState, type ChangeEvent } from 'react';
 import { useSelectItem } from '../hooks/useSelectItem';
+import { IngredientSearchForm } from '../components/IngredientSearchForm';
 
 interface Step {
   image: File | null;
@@ -16,6 +15,8 @@ interface Step {
 export const AddRecipe = () => {
   const { selectedItem, setSelectedItem } = useSelectItem();
   const [step, setStep] = useState<Step[]>([{ image: null, content: '' }]);
+
+  // console.log(selectedItem);
 
   const handleImageStep = (event: ChangeEvent<HTMLInputElement>, index: number) => {
     const newImage = [...step];
@@ -89,11 +90,10 @@ export const AddRecipe = () => {
           삭제
         </BasicButton>
       </TitleWrapper>
-      <IngredientSearchForm />
-      <IngredientList
-        titleList={['당근', '무', '오징어']}
-        setSelectedIngredient={setSelectedItem}
-        usedIngredient={selectedItem}
+      <IngredientSearchForm
+        isRecipePageSearch
+        selectedItem={selectedItem}
+        setSelectedItem={setSelectedItem}
       />
       <WriteContainer onSubmit={(e) => handleSubmit(e)}>
         <RecipeTitle placeholder="레시피 제목 입력" name="title" />

--- a/src/pages/MyRefrigerator.tsx
+++ b/src/pages/MyRefrigerator.tsx
@@ -1,13 +1,11 @@
 import { styled } from 'styled-components';
-import { IngredientSearchForm } from '../components/IngredientSearchForm';
 import { BasicTitle } from '../components/common/BasicTitle';
-import { IngredientList } from '../components/common/IngredientList';
-import { useSelectItem } from '../hooks/useSelectItem';
 import { HiTrash } from 'react-icons/hi';
+import { useSelectItem } from '../hooks/useSelectItem';
+import { IngredientSearchForm } from '../components/IngredientSearchForm';
 
 export const MyRefrigerator = () => {
   const { selectedItem, setSelectedItem } = useSelectItem();
-
   // console.log(selectedItem);
 
   return (
@@ -18,11 +16,10 @@ export const MyRefrigerator = () => {
           <SectionName>냉장실</SectionName>
           <HiTrash />
         </RefrigeSection>
-        <IngredientSearchForm />
-        <IngredientList
-          titleList={['당근', '닭고기', '무', '로즈마리']}
-          setSelectedIngredient={setSelectedItem}
-          usedIngredient={selectedItem}
+        <IngredientSearchForm
+          isRecipePageSearch={false}
+          selectedItem={selectedItem}
+          setSelectedItem={setSelectedItem}
         />
       </Container>
       <Container>
@@ -30,11 +27,10 @@ export const MyRefrigerator = () => {
           <SectionName>냉동실</SectionName>
           <HiTrash />
         </RefrigeSection>
-        <IngredientSearchForm />
-        <IngredientList
-          titleList={['당근', '닭고기', '무', '로즈마리']}
-          setSelectedIngredient={setSelectedItem}
-          usedIngredient={selectedItem}
+        <IngredientSearchForm
+          isRecipePageSearch={false}
+          selectedItem={selectedItem}
+          setSelectedItem={setSelectedItem}
         />
       </Container>
     </>


### PR DESCRIPTION
## 작업내용
- IngredientSearchForm은 이제 isRecipePageSearch값이 true냐 false냐에 따라 다르게 동작합니다.
- IngredientList컴포넌트를 IngredientSearchForm컴포넌트 안에 추가시켰습니다. 두개의 병합이 아닙니다. IngredientList컴포넌트 자체는 따로 있긴 합니다.
```HTML
 <IngredientSearchForm
        isRecipePageSearch
        selectedItem={selectedItem}
        setSelectedItem={setSelectedItem}
      />
```
![검색옵션](https://github.com/fridge-rescue/fridge-rescue-client/assets/107461545/4b12c282-af4a-427e-a512-c07216912f25)
- true일 경우엔 사용자가 재료를 타이핑하고 enter를 치면 클립으로 input창 안에 들어가게 됩니다.
- 추천된 검색어를 클릭하여 추가도 가능합니다.
-  "+"  버튼을 누르면 레시피를 작성하고 등록에 필요한 임시 재료가 추가되어 보여집니다.

![검색옵션2](https://github.com/fridge-rescue/fridge-rescue-client/assets/107461545/5a4b336b-e1df-48a1-9439-425d364793a9)
- false일 경우 사용자가 직접입력한 값을 enter키로 추가하지 못합니다. 추천된 재료들만 선택이 가능합니다.
-  "+" 버튼 역시 임시 재료가 추가되는것이 아닌 서버로 나의 냉장고 재료 추가 요청을 보냅니다.

## 작업목적
- 레시피 등록 페이지 재료검색 및 등록 플로우에 맞추기 위함