### PR TITLE
냉장고 구조대 #37 냉장고 페이지 UI 수정 및 전달 데이터 변경

### DIFF
--- a/src/components/IngredientInfo.tsx
+++ b/src/components/IngredientInfo.tsx
@@ -50,6 +50,7 @@ export const IngredientInfo = ({
               <p> 유통기한</p>
             </Title>
             <Expiration
+              style={isSave ? { backgroundColor: '#f8f8f8' } : { backgroundColor: 'white' }}
               required
               readOnly={isSave}
               type="date"
@@ -59,7 +60,13 @@ export const IngredientInfo = ({
             <Title>
               <p>간단 메모</p>
             </Title>
-            <Memo required readOnly={isSave} value={memo} onChange={(e) => handleMemoChange(e)} />
+            <Memo
+              style={isSave ? { backgroundColor: '#f8f8f8' } : { backgroundColor: 'white' }}
+              required
+              readOnly={isSave}
+              value={memo}
+              onChange={(e) => handleMemoChange(e)}
+            />
             <ButtonWrapper></ButtonWrapper>
           </Info>
         </AccordionDetails>
@@ -113,7 +120,6 @@ const Expiration = styled.input`
 const Memo = styled.textarea`
   width: 100%;
   resize: none;
-  height: 150px;
   border: none;
   border-radius: 5px;
   padding: 10px;

--- a/src/components/IngredientInfo.tsx
+++ b/src/components/IngredientInfo.tsx
@@ -1,6 +1,7 @@
 import { Accordion, AccordionDetails, AccordionSummary, Typography } from '@mui/material';
 import { useState } from 'react';
 import { styled } from 'styled-components';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 interface Props {
   name: string;
@@ -36,7 +37,11 @@ export const IngredientInfo = ({
   return (
     <Container>
       <Accordion expanded={expanded === name} onChange={handleChange(name)}>
-        <AccordionSummary aria-controls="panel1d-content" id="panel1d-header">
+        <AccordionSummary
+          aria-controls="panel1d-content"
+          id="panel1d-header"
+          expandIcon={<ExpandMoreIcon />}
+        >
           <Typography style={{ fontWeight: 700 }}>{name}</Typography>
         </AccordionSummary>
         <AccordionDetails>

--- a/src/components/IngredientInfo.tsx
+++ b/src/components/IngredientInfo.tsx
@@ -42,7 +42,7 @@ export const IngredientInfo = ({
           id="panel1d-header"
           expandIcon={<ExpandMoreIcon />}
         >
-          <Typography style={{ fontWeight: 700 }}>{name}</Typography>
+          <IngredientTitle>{name}</IngredientTitle>
         </AccordionSummary>
         <AccordionDetails>
           <Info>
@@ -81,6 +81,11 @@ const Container = styled.div`
   & > div {
     background-color: #f8f8f8;
   }
+`;
+
+const IngredientTitle = styled.p`
+  font-size: 20px;
+  font-weight: 700;
 `;
 
 const Info = styled.div`

--- a/src/components/IngredientInfo.tsx
+++ b/src/components/IngredientInfo.tsx
@@ -1,0 +1,131 @@
+import { Accordion, AccordionDetails, AccordionSummary, Typography } from '@mui/material';
+import { useState } from 'react';
+import { styled } from 'styled-components';
+
+interface Props {
+  name: string;
+  expiredAt: string;
+  memo: string;
+  updateIngredientDetails: (index: number, field: string, value: string) => void;
+  index: number;
+  isSave: boolean;
+}
+
+export const IngredientInfo = ({
+  name,
+  expiredAt,
+  memo,
+  updateIngredientDetails,
+  index,
+  isSave,
+}: Props) => {
+  const [expanded, setExpanded] = useState<string | false>('');
+
+  const handleChange = (panel: string) => (_event: React.SyntheticEvent, newExpanded: boolean) => {
+    setExpanded(newExpanded ? panel : false);
+  };
+
+  const handleExpiredAtChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    updateIngredientDetails(index, e.target.value, memo);
+  };
+
+  const handleMemoChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    updateIngredientDetails(index, expiredAt, e.target.value);
+  };
+
+  return (
+    <Container>
+      <Accordion expanded={expanded === name} onChange={handleChange(name)}>
+        <AccordionSummary aria-controls="panel1d-content" id="panel1d-header">
+          <Typography style={{ fontWeight: 700 }}>{name}</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Info>
+            <Title>
+              <p> 유통기한</p>
+            </Title>
+            <Expiration
+              required
+              readOnly={isSave}
+              type="date"
+              value={expiredAt}
+              onChange={handleExpiredAtChange}
+            ></Expiration>
+            <Title>
+              <p>간단 메모</p>
+            </Title>
+            <Memo required readOnly={isSave} value={memo} onChange={(e) => handleMemoChange(e)} />
+            <ButtonWrapper></ButtonWrapper>
+          </Info>
+        </AccordionDetails>
+      </Accordion>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  margin-top: 20px;
+
+  & > div {
+    background-color: #f8f8f8;
+  }
+`;
+
+const Info = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Title = styled.div`
+  font-size: 16px;
+  margin-bottom: 5px;
+  display: flex;
+  align-items: center;
+
+  & > svg {
+    fill: ${(props) => props.theme.colors.gray};
+    margin-left: 10px;
+    width: 20px;
+    height: 20px;
+    cursor: pointer;
+  }
+`;
+
+const Expiration = styled.input`
+  font-size: 14px;
+  height: 40px;
+  border: none;
+  border-radius: 5px;
+  padding: 0 10px;
+  margin-bottom: 30px;
+  transition: all 0.3s ease;
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const Memo = styled.textarea`
+  width: 100%;
+  resize: none;
+  height: 150px;
+  border: none;
+  border-radius: 5px;
+  padding: 10px;
+  font-size: 16px;
+  transition: all 0.3s ease;
+  &:focus {
+    outline: none;
+  }
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: end;
+  margin-top: 20px;
+
+  & > button {
+    width: 100px;
+    margin: 0 10px 0 10px;
+  }
+`;

--- a/src/components/IngredientInfo.tsx
+++ b/src/components/IngredientInfo.tsx
@@ -1,4 +1,4 @@
-import { Accordion, AccordionDetails, AccordionSummary, Typography } from '@mui/material';
+import { Accordion, AccordionDetails, AccordionSummary } from '@mui/material';
 import { useState } from 'react';
 import { styled } from 'styled-components';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';

--- a/src/components/IngredientSearchForm.tsx
+++ b/src/components/IngredientSearchForm.tsx
@@ -2,24 +2,22 @@ import { Chip, InputAdornment, TextField } from '@mui/material';
 import type { ChangeEvent } from 'react';
 import { styled } from 'styled-components';
 import { BasicButton } from './common/BasicButton';
-import { IngredientList } from './common/IngredientList';
 import { theme } from '../styles/theme';
 import { device } from '../styles/media';
 import { useIngredient } from '../hooks/useIngredient';
 
 interface SearchFormPorps {
-  selectedItem: string[];
-  setSelectedItem: React.Dispatch<React.SetStateAction<string[]>>;
+  addItemList: string[];
+  setAddItemList: React.Dispatch<React.SetStateAction<string[]>>;
   isRecipePageSearch: boolean;
 }
 
 export const IngredientSearchForm = ({
-  selectedItem,
-  setSelectedItem,
+  addItemList,
+  setAddItemList,
   isRecipePageSearch,
 }: SearchFormPorps) => {
   const {
-    addItemList,
     query,
     visible,
     selectedQuery,
@@ -28,7 +26,7 @@ export const IngredientSearchForm = ({
     addIngredient,
     handleItemList,
     setQuery,
-  } = useIngredient();
+  } = useIngredient({ addItemList, setAddItemList });
 
   return (
     <>
@@ -36,6 +34,7 @@ export const IngredientSearchForm = ({
         <SearchWrapper>
           <TextField
             value={query}
+            placeholder="재료를 검색해 주세요."
             onChange={(event: ChangeEvent<HTMLInputElement>) => setQuery(event.target.value)}
             InputProps={{
               startAdornment: (
@@ -53,36 +52,24 @@ export const IngredientSearchForm = ({
             }}
           />
           <BasicButton
-            type={isRecipePageSearch ? 'button' : 'submit'}
+            type="button"
             $bgcolor={theme.colors.orange}
             $fontcolor={theme.colors.white}
-            onClick={isRecipePageSearch ? handleItemList : undefined}
+            onClick={handleItemList}
           >
             +
           </BasicButton>
         </SearchWrapper>
         {visible && (
           <SearchedList>
-            {new Array(5).fill(1).map((_, i) => (
+            {['당근', '딸기', '로즈마리'].map((e, i) => (
               <SearchedItem key={i} onClick={handleSelect}>
-                <p>당근</p>
+                <p>{e}</p>
               </SearchedItem>
             ))}
           </SearchedList>
         )}
       </Form>
-      <IngredientList
-        setSelectedIngredient={setSelectedItem}
-        usedIngredient={selectedItem}
-        titleList={['원래 냉장고 재료']}
-      />
-      {isRecipePageSearch && (
-        <IngredientList
-          setSelectedIngredient={setSelectedItem}
-          usedIngredient={selectedItem}
-          titleList={addItemList}
-        />
-      )}
     </>
   );
 };

--- a/src/hooks/useIngredient.ts
+++ b/src/hooks/useIngredient.ts
@@ -1,7 +1,11 @@
 import { useState, useEffect } from 'react';
 
-export const useIngredient = () => {
-  const [addItemList, setAddItemList] = useState<string[]>([]);
+interface IngredientProps {
+  addItemList: string[];
+  setAddItemList: React.Dispatch<React.SetStateAction<string[]>>;
+}
+
+export const useIngredient = ({ addItemList, setAddItemList }: IngredientProps) => {
   const [query, setQuery] = useState('');
   const [visible, setVisible] = useState(false);
   const [selectedQuery, setSelectedQuery] = useState<string[]>([]);
@@ -29,9 +33,6 @@ export const useIngredient = () => {
       }
       setQuery('');
     }
-    if (selectedQuery.length > 0) {
-      // console.log('사용자 냉장고에 재료 추가');
-    }
   };
 
   const handleItemList = () => {
@@ -40,7 +41,6 @@ export const useIngredient = () => {
   };
 
   return {
-    addItemList,
     query,
     visible,
     selectedQuery,

--- a/src/hooks/useSelectItem.ts
+++ b/src/hooks/useSelectItem.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 export const useSelectItem = () => {
   const [selectedItem, setSelectedItem] = useState<string[]>([]);
+  const [addItemList, setAddItemList] = useState<string[]>([]);
 
-  return { selectedItem, setSelectedItem };
+  return { selectedItem, setSelectedItem, addItemList, setAddItemList };
 };

--- a/src/pages/AddRecipe.tsx
+++ b/src/pages/AddRecipe.tsx
@@ -16,14 +16,6 @@ interface Step {
 export const AddRecipe = () => {
   const { selectedItem, setSelectedItem, addItemList, setAddItemList } = useSelectItem();
   const [step, setStep] = useState<Step[]>([{ image: null, content: '' }]);
-  const [thumbnail, setThumbnail] = useState<File | null>(null);
-
-  const onThumbnailChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (event.target.files && event.target.files[0]) {
-      const thumbnail = event.target.files && event.target.files[0];
-      setThumbnail(thumbnail);
-    }
-  };
 
   const handleImageStep = (event: ChangeEvent<HTMLInputElement>, index: number) => {
     const newImage = [...step];
@@ -79,14 +71,6 @@ export const AddRecipe = () => {
 
     formData.append(`recipeTitle`, title);
 
-    // TODO: 예외처리 보강
-    if (thumbnail) {
-      formData.append(`recipeImage`, thumbnail);
-    } else {
-      console.error('썸네일을 등록해 주세요!');
-      return;
-    }
-
     step.forEach((item, index) => {
       if (item.image) {
         formData.append(`step[${index}][image]`, item.image);
@@ -119,26 +103,7 @@ export const AddRecipe = () => {
       />
       <WriteContainer onSubmit={(e) => handleSubmit(e)}>
         <RecipeTitle placeholder="레시피 제목 입력" name="title" />
-        <Thumbnail>
-          <ImageContainer>
-            {thumbnail ? <ImagePreview src={URL.createObjectURL(thumbnail)} /> : <Placeholder />}
-          </ImageContainer>
-          <InputContainer>
-            <Input type="file" accept="image/*" id="file" onChange={onThumbnailChange} />
-            {thumbnail ? (
-              <BasicButton
-                type="button"
-                $bgcolor={theme.colors.orange}
-                $fontcolor={theme.colors.white}
-                onClick={() => setThumbnail(null)}
-              >
-                썸네일 삭제
-              </BasicButton>
-            ) : (
-              <InputLabel htmlFor="file">썸네일 업로드</InputLabel>
-            )}
-          </InputContainer>
-        </Thumbnail>
+
         {step.map((e, i) => (
           <RecipeStep
             key={i}
@@ -196,50 +161,4 @@ const ButtonWrapper = styled.div`
   gap: 4px;
   margin-top: 40px;
   justify-content: end;
-`;
-
-const Thumbnail = styled.div`
-  margin: 10px 0 40px 0;
-`;
-
-const ImageContainer = styled.div`
-  width: 100%;
-  height: 400px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-bottom: 10px;
-`;
-
-const ImagePreview = styled.img`
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-`;
-
-const Placeholder = styled.div`
-  width: 100%;
-  height: 100%;
-  background-color: ${(props) => props.theme.colors.gray};
-`;
-
-const Input = styled.input`
-  display: none;
-`;
-
-const InputContainer = styled.div`
-  position: relative;
-`;
-
-const InputLabel = styled.label`
-  font-size: 14px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 10px;
-  padding: 10px 20px;
-  background-color: ${(props) => props.theme.colors.orange};
-  color: white;
-  cursor: pointer;
-  margin-right: 5px;
 `;

--- a/src/pages/AddRecipe.tsx
+++ b/src/pages/AddRecipe.tsx
@@ -6,6 +6,7 @@ import { RecipeStep } from '../components/RecipeStep';
 import { useState, type ChangeEvent } from 'react';
 import { useSelectItem } from '../hooks/useSelectItem';
 import { IngredientSearchForm } from '../components/IngredientSearchForm';
+import { IngredientList } from '../components/common/IngredientList';
 
 interface Step {
   image: File | null;
@@ -13,7 +14,7 @@ interface Step {
 }
 
 export const AddRecipe = () => {
-  const { selectedItem, setSelectedItem } = useSelectItem();
+  const { selectedItem, setSelectedItem, addItemList, setAddItemList } = useSelectItem();
   const [step, setStep] = useState<Step[]>([{ image: null, content: '' }]);
 
   // console.log(selectedItem);
@@ -89,8 +90,18 @@ export const AddRecipe = () => {
       </TitleWrapper>
       <IngredientSearchForm
         isRecipePageSearch
-        selectedItem={selectedItem}
-        setSelectedItem={setSelectedItem}
+        addItemList={addItemList}
+        setAddItemList={setAddItemList}
+      />
+      <IngredientList
+        setSelectedIngredient={setSelectedItem}
+        usedIngredient={selectedItem}
+        titleList={['원래 냉장고 재료']}
+      />
+      <IngredientList
+        setSelectedIngredient={setSelectedItem}
+        usedIngredient={selectedItem}
+        titleList={addItemList}
       />
       <WriteContainer onSubmit={(e) => handleSubmit(e)}>
         <RecipeTitle placeholder="레시피 제목 입력" name="title" />

--- a/src/pages/AddRecipe.tsx
+++ b/src/pages/AddRecipe.tsx
@@ -16,8 +16,14 @@ interface Step {
 export const AddRecipe = () => {
   const { selectedItem, setSelectedItem, addItemList, setAddItemList } = useSelectItem();
   const [step, setStep] = useState<Step[]>([{ image: null, content: '' }]);
+  const [thumbnail, setThumbnail] = useState<File | null>(null);
 
-  // console.log(selectedItem);
+  const onThumbnailChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files[0]) {
+      const thumbnail = event.target.files && event.target.files[0];
+      setThumbnail(thumbnail);
+    }
+  };
 
   const handleImageStep = (event: ChangeEvent<HTMLInputElement>, index: number) => {
     const newImage = [...step];
@@ -73,6 +79,14 @@ export const AddRecipe = () => {
 
     formData.append(`recipeTitle`, title);
 
+    // TODO: 예외처리 보강
+    if (thumbnail) {
+      formData.append(`recipeImage`, thumbnail);
+    } else {
+      console.error('썸네일을 등록해 주세요!');
+      return;
+    }
+
     step.forEach((item, index) => {
       if (item.image) {
         formData.append(`step[${index}][image]`, item.image);
@@ -105,6 +119,26 @@ export const AddRecipe = () => {
       />
       <WriteContainer onSubmit={(e) => handleSubmit(e)}>
         <RecipeTitle placeholder="레시피 제목 입력" name="title" />
+        <Thumbnail>
+          <ImageContainer>
+            {thumbnail ? <ImagePreview src={URL.createObjectURL(thumbnail)} /> : <Placeholder />}
+          </ImageContainer>
+          <InputContainer>
+            <Input type="file" accept="image/*" id="file" onChange={onThumbnailChange} />
+            {thumbnail ? (
+              <BasicButton
+                type="button"
+                $bgcolor={theme.colors.orange}
+                $fontcolor={theme.colors.white}
+                onClick={() => setThumbnail(null)}
+              >
+                썸네일 삭제
+              </BasicButton>
+            ) : (
+              <InputLabel htmlFor="file">썸네일 업로드</InputLabel>
+            )}
+          </InputContainer>
+        </Thumbnail>
         {step.map((e, i) => (
           <RecipeStep
             key={i}
@@ -162,4 +196,50 @@ const ButtonWrapper = styled.div`
   gap: 4px;
   margin-top: 40px;
   justify-content: end;
+`;
+
+const Thumbnail = styled.div`
+  margin: 10px 0 40px 0;
+`;
+
+const ImageContainer = styled.div`
+  width: 100%;
+  height: 400px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 10px;
+`;
+
+const ImagePreview = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+const Placeholder = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: ${(props) => props.theme.colors.gray};
+`;
+
+const Input = styled.input`
+  display: none;
+`;
+
+const InputContainer = styled.div`
+  position: relative;
+`;
+
+const InputLabel = styled.label`
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  padding: 10px 20px;
+  background-color: ${(props) => props.theme.colors.orange};
+  color: white;
+  cursor: pointer;
+  margin-right: 5px;
 `;

--- a/src/pages/AddRecipe.tsx
+++ b/src/pages/AddRecipe.tsx
@@ -16,6 +16,7 @@ interface Step {
 export const AddRecipe = () => {
   const { selectedItem, setSelectedItem, addItemList, setAddItemList } = useSelectItem();
   const [step, setStep] = useState<Step[]>([{ image: null, content: '' }]);
+  const [thumbnail, setThumbnail] = useState<File | null>(null);
 
   const handleImageStep = (event: ChangeEvent<HTMLInputElement>, index: number) => {
     const newImage = [...step];
@@ -27,6 +28,13 @@ export const AddRecipe = () => {
         content: newImage[index].content,
       };
       setStep(newImage);
+    }
+  };
+
+  const onThumbnailChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files[0]) {
+      const thumbnail = event.target.files && event.target.files[0];
+      setThumbnail(thumbnail);
     }
   };
 
@@ -71,6 +79,14 @@ export const AddRecipe = () => {
 
     formData.append(`recipeTitle`, title);
 
+    // TODO: 예외처리 보강
+    if (thumbnail) {
+      formData.append(`recipeImage`, thumbnail);
+    } else {
+      console.error('썸네일을 등록해 주세요!');
+      return;
+    }
+
     step.forEach((item, index) => {
       if (item.image) {
         formData.append(`step[${index}][image]`, item.image);
@@ -103,7 +119,26 @@ export const AddRecipe = () => {
       />
       <WriteContainer onSubmit={(e) => handleSubmit(e)}>
         <RecipeTitle placeholder="레시피 제목 입력" name="title" />
-
+        <Thumbnail>
+          <ImageContainer>
+            {thumbnail ? <ImagePreview src={URL.createObjectURL(thumbnail)} /> : <Placeholder />}
+          </ImageContainer>
+          <InputContainer>
+            <Input type="file" accept="image/*" id="thumbnail" onChange={onThumbnailChange} />
+            {thumbnail ? (
+              <BasicButton
+                type="button"
+                $bgcolor={theme.colors.orange}
+                $fontcolor={theme.colors.white}
+                onClick={() => setThumbnail(null)}
+              >
+                썸네일 삭제
+              </BasicButton>
+            ) : (
+              <InputLabel htmlFor="thumbnail">썸네일 업로드</InputLabel>
+            )}
+          </InputContainer>
+        </Thumbnail>
         {step.map((e, i) => (
           <RecipeStep
             key={i}
@@ -161,4 +196,50 @@ const ButtonWrapper = styled.div`
   gap: 4px;
   margin-top: 40px;
   justify-content: end;
+`;
+
+const Thumbnail = styled.div`
+  margin: 10px 0 40px 0;
+`;
+
+const ImageContainer = styled.div`
+  width: 100%;
+  height: 400px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 10px;
+`;
+
+const ImagePreview = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+const Placeholder = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: ${(props) => props.theme.colors.gray};
+`;
+
+const Input = styled.input`
+  display: none;
+`;
+
+const InputContainer = styled.div`
+  position: relative;
+`;
+
+const InputLabel = styled.label`
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  padding: 10px 20px;
+  background-color: ${(props) => props.theme.colors.orange};
+  color: white;
+  cursor: pointer;
+  margin-right: 5px;
 `;

--- a/src/pages/MyRefrigerator.tsx
+++ b/src/pages/MyRefrigerator.tsx
@@ -20,7 +20,7 @@ export const MyRefrigerator = () => {
   );
   const [isSave, setIsSave] = useState(false);
 
-  console.log(ingredientDetails);
+  // console.log(ingredientDetails);
 
   useEffect(() => {
     setIsSave(false);
@@ -49,7 +49,7 @@ export const MyRefrigerator = () => {
       return;
     }
     setIsSave(!isSave);
-    console.log(ingredientDetails);
+    // console.log(ingredientDetails);
   };
 
   // const removeIngredient = (index: number) => {
@@ -67,17 +67,19 @@ export const MyRefrigerator = () => {
           addItemList={addItemList}
           setAddItemList={setAddItemList}
         />
-        {ingredientDetails.map((ingredient, index) => (
-          <IngredientInfo
-            key={index}
-            name={ingredient.name}
-            expiredAt={ingredient.expiredAt}
-            memo={ingredient.memo}
-            updateIngredientDetails={updateIngredientDetails}
-            index={index}
-            isSave={isSave}
-          />
-        ))}
+        <Wrapper>
+          {ingredientDetails.map((ingredient, index) => (
+            <IngredientInfo
+              key={index}
+              name={ingredient.name}
+              expiredAt={ingredient.expiredAt}
+              memo={ingredient.memo}
+              updateIngredientDetails={updateIngredientDetails}
+              index={index}
+              isSave={isSave}
+            />
+          ))}
+        </Wrapper>
         {isSave ? (
           <BasicButton
             type="button"
@@ -110,6 +112,12 @@ const Container = styled.div`
   & > button {
     margin-top: 30px;
   }
+`;
+
+const Wrapper = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
 `;
 
 const RefrigeSection = styled.div`

--- a/src/pages/MyRefrigerator.tsx
+++ b/src/pages/MyRefrigerator.tsx
@@ -1,37 +1,92 @@
 import { styled } from 'styled-components';
 import { BasicTitle } from '../components/common/BasicTitle';
-import { HiTrash } from 'react-icons/hi';
 import { useSelectItem } from '../hooks/useSelectItem';
 import { IngredientSearchForm } from '../components/IngredientSearchForm';
+import { IngredientInfo } from '../components/IngredientInfo';
+import { BasicButton } from '../components/common/BasicButton';
+import { theme } from '../styles/theme';
+import { useEffect, useState } from 'react';
+
+interface Ingredient {
+  name: string;
+  expiredAt: string;
+  memo: string;
+}
 
 export const MyRefrigerator = () => {
-  const { selectedItem, setSelectedItem } = useSelectItem();
-  // console.log(selectedItem);
+  const { addItemList, setAddItemList } = useSelectItem();
+  const [ingredientDetails, setIngredientDetails] = useState<Ingredient[]>(
+    addItemList.map((name) => ({ name, expiredAt: '', memo: '' }))
+  );
+  const [isSave, setIsSave] = useState(false);
+
+  useEffect(() => {
+    setIngredientDetails(addItemList.map((name) => ({ name, expiredAt: '', memo: '' })));
+    setIsSave(false);
+  }, [addItemList]);
+
+  const updateIngredientDetails = (index: number, expiredAt: string, memo: string) => {
+    const newDetails = [...ingredientDetails];
+    newDetails[index] = { ...newDetails[index], expiredAt, memo };
+    setIngredientDetails(newDetails);
+  };
+
+  const handleSave = async () => {
+    const hasEmptyExpiredAt = ingredientDetails.some((item) => item.expiredAt === '');
+
+    if (hasEmptyExpiredAt) {
+      // alert('모든 재료의 유통기한을 입력해주세요.');
+      return;
+    }
+    setIsSave(!isSave);
+    console.log(ingredientDetails);
+  };
+
+  // const removeIngredient = (index: number) => {
+  //   setAddItemList(addItemList.filter((_, i) => i !== index));
+  //   setIngredientDetails(ingredientDetails.filter((_, i) => i !== index));
+  // };
 
   return (
     <>
       <BasicTitle title="나의 냉장고" />
       <Container>
-        <RefrigeSection>
-          <SectionName>냉장실</SectionName>
-          <HiTrash />
-        </RefrigeSection>
+        <RefrigeSection></RefrigeSection>
         <IngredientSearchForm
           isRecipePageSearch={false}
-          selectedItem={selectedItem}
-          setSelectedItem={setSelectedItem}
+          addItemList={addItemList}
+          setAddItemList={setAddItemList}
         />
-      </Container>
-      <Container>
-        <RefrigeSection>
-          <SectionName>냉동실</SectionName>
-          <HiTrash />
-        </RefrigeSection>
-        <IngredientSearchForm
-          isRecipePageSearch={false}
-          selectedItem={selectedItem}
-          setSelectedItem={setSelectedItem}
-        />
+        {ingredientDetails.map((ingredient, index) => (
+          <IngredientInfo
+            key={index}
+            name={ingredient.name}
+            expiredAt={ingredient.expiredAt}
+            memo={ingredient.memo}
+            updateIngredientDetails={updateIngredientDetails}
+            index={index}
+            isSave={isSave}
+          />
+        ))}
+        {isSave ? (
+          <BasicButton
+            type="button"
+            $bgcolor={theme.colors.orange}
+            $fontcolor={theme.colors.white}
+            onClick={handleSave}
+          >
+            수정
+          </BasicButton>
+        ) : (
+          <BasicButton
+            type="button"
+            $bgcolor={theme.colors.orange}
+            $fontcolor={theme.colors.white}
+            onClick={handleSave}
+          >
+            저장
+          </BasicButton>
+        )}
       </Container>
     </>
   );
@@ -41,7 +96,10 @@ const Container = styled.div`
   margin-bottom: 50px;
   padding: 45px 20px 45px 20px;
   border-radius: 15px;
-  background-color: #f8f8f8;
+
+  & > button {
+    margin-top: 30px;
+  }
 `;
 
 const RefrigeSection = styled.div`
@@ -59,8 +117,4 @@ const RefrigeSection = styled.div`
     margin-right: 13px;
     fill: ${(props) => props.theme.colors.darkGray};
   }
-`;
-
-const SectionName = styled.h3`
-  font-size: 20px;
 `;

--- a/src/pages/MyRefrigerator.tsx
+++ b/src/pages/MyRefrigerator.tsx
@@ -20,9 +20,18 @@ export const MyRefrigerator = () => {
   );
   const [isSave, setIsSave] = useState(false);
 
+  console.log(ingredientDetails);
+
   useEffect(() => {
-    setIngredientDetails(addItemList.map((name) => ({ name, expiredAt: '', memo: '' })));
     setIsSave(false);
+    const newItems = addItemList.filter(
+      (item) => !ingredientDetails.some((detail) => detail.name === item)
+    );
+
+    const newDetails = newItems.map((name) => ({ name, expiredAt: '', memo: '' }));
+
+    setIngredientDetails((prevDetails) => [...prevDetails, ...newDetails]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [addItemList]);
 
   const updateIngredientDetails = (index: number, expiredAt: string, memo: string) => {
@@ -35,7 +44,8 @@ export const MyRefrigerator = () => {
     const hasEmptyExpiredAt = ingredientDetails.some((item) => item.expiredAt === '');
 
     if (hasEmptyExpiredAt) {
-      // alert('모든 재료의 유통기한을 입력해주세요.');
+      // 임시 알람
+      alert('모든 재료의 유통기한을 입력해주세요.');
       return;
     }
     setIsSave(!isSave);


### PR DESCRIPTION
## 작업내용
![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/107461545/9dabc725-6fc5-4ccf-bc7f-b3bcc2fa6d18)

- 검색창을 살리고 전체 저장과 개별 수정과 삭제를 구현하는데 생각보다 시간이 많이 소요되었습니다.
- 저장버튼을 누르면 저장버튼이 수정으로 버튼이 바뀌고 유통기한과 메모는 readOnly가 됩니다.
- 수정버튼을  누르면 readOnly가 풀립니다.
- 삭제 부분은 아직 어떤식으로 할건지 합의가 안되어 일단은 삭제하였습니다.

## 작업목적
- 냉장고 페이지 재료 추가 플로우에 맞게 UI및 전달 데이터 변경