### PR TITLE
냉장고를 부탁해#50 axios 인터셉터 설정

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { BASE_URL } from '../constants/api';
+import { checkAndSetToken, handleTokenError } from './interceptors';
 
 // 사진 보낼때는 header부분 변경 필요 / 옵션 변경은 자유롭게!
 export const axiosInstance = axios.create({
@@ -10,3 +11,8 @@ export const axiosInstance = axios.create({
   },
   withCredentials: true,
 });
+
+// TODO: API에러시 함수 작성하여 두번째 인자로 넣기
+axiosInstance.interceptors.request.use(checkAndSetToken, (error) => Promise.reject(error));
+
+axiosInstance.interceptors.response.use((response) => response, handleTokenError);

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -2,8 +2,8 @@ import axios from 'axios';
 import { BASE_URL } from '../constants/api';
 import { checkAndSetToken, handleTokenError } from './interceptors';
 
-// 사진 보낼때는 header부분 변경 필요 / 옵션 변경은 자유롭게!
-export const axiosInstance = axios.create({
+// 인증이 필요한 페이지에서 토큰검사 후 데이터를 패칭할때 사용할 인스턴스
+export const axiosAuth = axios.create({
   baseURL: BASE_URL,
   timeout: 5000, // 요청 타임아웃(옵션)
   headers: {
@@ -12,7 +12,16 @@ export const axiosInstance = axios.create({
   withCredentials: true,
 });
 
-// TODO: API에러시 함수 작성하여 두번째 인자로 넣기
-axiosInstance.interceptors.request.use(checkAndSetToken, (error) => Promise.reject(error));
+// 인증이 필요하지 않은 페이지에서 데이터를 패칭할때 사용할 인스턴스
+export const axiosDefault = axios.create({
+  baseURL: BASE_URL,
+  timeout: 5000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
 
-axiosInstance.interceptors.response.use((response) => response, handleTokenError);
+// TODO: API에러시 함수 작성하여 두번째 인자로 넣기
+axiosAuth.interceptors.request.use(checkAndSetToken, (error) => Promise.reject(error));
+
+axiosAuth.interceptors.response.use((response) => response, handleTokenError);

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -6,7 +6,7 @@ import type { Token } from '../types/tokenType';
 export const checkAndSetToken = (config: InternalAxiosRequestConfig) => {
   if (!config.headers || config.headers.Authorization) return config;
 
-  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
+  const accessToken = sessionStorage.getItem(ACCESS_TOKEN_KEY);
   if (!accessToken) {
     window.location.href = ROOT_URL;
     throw new Error('토큰이 유효하지 않습니다.');
@@ -32,7 +32,7 @@ export const handleTokenError = async (error: AxiosError) => {
 
         originalRequest.headers.Authorization = `Bearer ${accessToken}`;
 
-        localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+        sessionStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
 
         return axiosAuth(originalRequest);
       }

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -1,0 +1,44 @@
+import type { AxiosError, InternalAxiosRequestConfig } from 'axios';
+import { ACCESS_TOKEN_KEY, END_POINTS } from '../constants/api';
+import { axiosInstance } from './axiosInstance';
+import type { Token } from '../types/tokenType';
+
+export const checkAndSetToken = (config: InternalAxiosRequestConfig) => {
+  if (!config.headers || !config.headers.Authorization) return config;
+
+  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
+  if (!accessToken) {
+    throw new Error('토큰이 유효하지 않습니다.');
+  }
+
+  // eslint-disable-next-line no-param-reassign
+  config.headers.Authorization = `Bearer ${accessToken}`;
+
+  return config;
+};
+
+export const handleTokenError = async (error: AxiosError) => {
+  const originalRequest = error.config;
+
+  if (!error.response || !originalRequest) throw new Error('에러가 발생했습니다.');
+
+  if (error.response && error.response.status === 401) {
+    try {
+      const response = await axiosInstance.post<Token>(END_POINTS.TOKEN);
+
+      if (response.status === 200) {
+        const { accessToken } = response.data;
+
+        originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+
+        localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+
+        return axiosInstance(originalRequest);
+      }
+    } catch (error) {
+      throw new Error(`${error}`);
+    }
+  }
+
+  throw new Error(`${error}`);
+};

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -1,13 +1,14 @@
 import type { AxiosError, InternalAxiosRequestConfig } from 'axios';
-import { ACCESS_TOKEN_KEY, END_POINTS } from '../constants/api';
-import { axiosInstance } from './axiosInstance';
+import { ACCESS_TOKEN_KEY, END_POINTS, ROOT_URL } from '../constants/api';
+import { axiosAuth } from './axiosInstance';
 import type { Token } from '../types/tokenType';
 
 export const checkAndSetToken = (config: InternalAxiosRequestConfig) => {
-  if (!config.headers || !config.headers.Authorization) return config;
+  if (!config.headers || config.headers.Authorization) return config;
 
   const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
   if (!accessToken) {
+    window.location.href = ROOT_URL;
     throw new Error('토큰이 유효하지 않습니다.');
   }
 
@@ -24,7 +25,7 @@ export const handleTokenError = async (error: AxiosError) => {
 
   if (error.response && error.response.status === 401) {
     try {
-      const response = await axiosInstance.post<Token>(END_POINTS.TOKEN);
+      const response = await axiosAuth.post<Token>(END_POINTS.TOKEN);
 
       if (response.status === 200) {
         const { accessToken } = response.data;
@@ -33,7 +34,7 @@ export const handleTokenError = async (error: AxiosError) => {
 
         localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
 
-        return axiosInstance(originalRequest);
+        return axiosAuth(originalRequest);
       }
     } catch (error) {
       throw new Error(`${error}`);

--- a/src/api/recipe/getNewRecipe.ts
+++ b/src/api/recipe/getNewRecipe.ts
@@ -1,10 +1,10 @@
 import { END_POINTS } from '../../constants/api';
 import type { Recipe } from '../../types/recipeType';
-import { axiosInstance } from '../axiosInstance';
+import { axiosDefault } from '../axiosInstance';
 
 export const getNewRecipe = async () => {
   try {
-    const response = await axiosInstance.get<Recipe[]>(END_POINTS.RECIPES);
+    const response = await axiosDefault.get<Recipe[]>(END_POINTS.RECIPES);
     return response.data;
   } catch (error) {
     throw new Error(`${error}`);

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,5 +1,7 @@
 export const BASE_URL = 'http://localhost:3001' as const; // TODO: 이후에 서버 올라가면 변경
 
+export const ROOT_URL = 'http://localhost:5173/';
+
 export const ACCESS_TOKEN_KEY = 'refrigeKey' as const; // TODO: 임시 로컬스토리지 key 임으로 추후 합의 후 변경 필요
 
 export const END_POINTS = {

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,6 +1,12 @@
 export const BASE_URL = 'http://localhost:3001' as const; // TODO: 이후에 서버 올라가면 변경
 
-export const END_POINTS = { MEMBERS: 'members', RECIPES: 'recipes' } as const;
+export const ACCESS_TOKEN_KEY = 'refrigeKey' as const; // TODO: 임시 로컬스토리지 key 임으로 추후 합의 후 변경 필요
+
+export const END_POINTS = {
+  MEMBERS: 'members',
+  RECIPES: 'recipes',
+  TOKEN: 'token/refresh',
+} as const;
 
 export const HTTP_STATUS_CODE = {} as const;
 

--- a/src/types/tokenType.ts
+++ b/src/types/tokenType.ts
@@ -1,0 +1,3 @@
+export interface Token {
+  accessToken: string;
+}


### PR DESCRIPTION
## 작업내용
- axios 인스턴스에 각각 res,req interceptors를 적용하였습니다.
```javascript
axiosInstance.interceptors.request.use(checkAndSetToken, (error) => Promise.reject(error));
axiosInstance.interceptors.response.use((response) => response, handleTokenError);
```
- request일때는 토큰 유무를 검사하고 로컬스토리지에서 가져와 서버로 전송합니다.
- response에서는 토큰이 만료되어 서버가 401에러를 돌려주면 토큰재발급 요청을 하고 새로운 토큰을 받아와 설정합니다.

- 인증이 필요한 페이지에서 데이터 패칭을 할때는 토큰검사를 수행하는 axiosAuth 를, 인증이 필요하지 않은 페이지에서 토큰검사를 하지 않고 패칭하는 axiosDefault를 각각 생성하였습니다.
- axiosAuth 에는 res,req interceptors 설정이 되어 있습니다.
- Refresh Token이 서버에서  HTTP-Only 쿠키로 내려오지 않고 header에 포함되어 내려온다면 프론트단에서 Refresh Token을 어디에 어떤 방식으로 저장할지 결정이 필요합니다.
- 리프레쉬 토큰을 프론트단에서 다루게 된다면 보안 상으로는 좋지 않을것 같습니다.