### PR TITLE
냉장고를 부탁해 #52 나의 냉장고 재료 수정 삭제 방식 변경 및 UI 변경

### DIFF
--- a/src/api/ingredient/getIngredient.ts
+++ b/src/api/ingredient/getIngredient.ts
@@ -1,0 +1,12 @@
+import { END_POINTS } from '../../constants/api';
+import type { Ingredient } from '../../types/ingredientType';
+import { axiosDefault } from '../axiosInstance';
+
+export const getIngredient = async () => {
+  try {
+    const response = await axiosDefault.get<Ingredient[]>(END_POINTS.INGREDIENT);
+    return response.data;
+  } catch (error) {
+    throw new Error(`${error}`);
+  }
+};

--- a/src/api/ingredient/ingredientSuggest.ts
+++ b/src/api/ingredient/ingredientSuggest.ts
@@ -1,0 +1,12 @@
+import { END_POINTS } from '../../constants/api';
+import type { Suggest } from '../../types/ingredientType';
+import { axiosDefault } from '../axiosInstance';
+
+export const getIngredientSuggest = async () => {
+  try {
+    const response = await axiosDefault.get<Suggest[]>(END_POINTS.SUGGEST);
+    return response.data;
+  } catch (error) {
+    throw new Error(`${error}`);
+  }
+};

--- a/src/components/AddIngredientInfo.tsx
+++ b/src/components/AddIngredientInfo.tsx
@@ -1,51 +1,41 @@
-import { Accordion, AccordionDetails, AccordionSummary } from '@mui/material';
-import { useState } from 'react';
 import { styled } from 'styled-components';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { BasicButton } from './common/BasicButton';
 import { theme } from '../styles/theme';
 import { device } from '../styles/media';
+import type { Ingredient } from '../types/ingredientType';
 
 interface Props {
-  name: string;
-  expiredAt: string;
-  memo: string;
   handleIngredientDetails: (index: number, field: string, value: string) => void;
-  index: number;
+  deleteAddedIngredient: (index: number) => void;
+  ingredientDetails: Ingredient[];
 }
 
 export const AddIngredientInfo = ({
-  name,
-  expiredAt,
-  memo,
   handleIngredientDetails,
-  index,
+  deleteAddedIngredient,
+  ingredientDetails,
 }: Props) => {
-  const [expanded, setExpanded] = useState<string | false>('');
-
-  const handleChange = (panel: string) => (_event: React.SyntheticEvent, newExpanded: boolean) => {
-    setExpanded(newExpanded ? panel : false);
-  };
-
-  const handleExpiredAtChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleExpiredAtChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    index: number,
+    memo: string
+  ) => {
     handleIngredientDetails(index, e.target.value, memo);
   };
 
-  const handleMemoChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const handleMemoChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement>,
+    index: number,
+    expiredAt: string
+  ) => {
     handleIngredientDetails(index, expiredAt, e.target.value);
   };
 
   return (
-    <Container>
-      <Accordion expanded={expanded === name} onChange={handleChange(name)}>
-        <AccordionSummary
-          aria-controls="panel1d-content"
-          id="panel1d-header"
-          expandIcon={<ExpandMoreIcon />}
-        >
-          <IngredientTitle>{name}</IngredientTitle>
-        </AccordionSummary>
-        <AccordionDetails>
+    <>
+      {ingredientDetails.map((ingredient, index) => (
+        <Container key={index}>
+          <IngredientTitle>{ingredient.name}</IngredientTitle>
           <Info>
             <Section>
               <Title>
@@ -54,27 +44,32 @@ export const AddIngredientInfo = ({
               <Expiration
                 required
                 type="date"
-                value={expiredAt}
-                onChange={handleExpiredAtChange}
+                value={ingredient.expiredAt}
+                onChange={(e) => handleExpiredAtChange(e, index, ingredient.memo)}
               ></Expiration>
             </Section>
             <Section>
               <Title>
                 <p>간단 메모</p>
               </Title>
-              <Memo required value={memo} onChange={(e) => handleMemoChange(e)} />
+              <Memo
+                required
+                value={ingredient.memo}
+                onChange={(e) => handleMemoChange(e, index, ingredient.expiredAt)}
+              />
             </Section>
             <BasicButton
               type="button"
               $bgcolor={theme.colors.orange}
               $fontcolor={theme.colors.white}
+              onClick={() => deleteAddedIngredient(index)}
             >
               삭제
             </BasicButton>
           </Info>
-        </AccordionDetails>
-      </Accordion>
-    </Container>
+        </Container>
+      ))}
+    </>
   );
 };
 

--- a/src/components/AddIngredientInfo.tsx
+++ b/src/components/AddIngredientInfo.tsx
@@ -78,7 +78,9 @@ const Container = styled.div`
   width: 100%;
 
   & > div {
-    background-color: #f8f8f8;
+    background-color: ${(props) => props.theme.colors.grayishWhite};
+    border-radius: 10px;
+    padding: 10px;
   }
 `;
 
@@ -90,7 +92,8 @@ const IngredientTitle = styled.p`
 const Info = styled.div`
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: space-around;
+  padding: 14px;
 
   & > button {
     max-width: 50px;
@@ -137,7 +140,6 @@ const Expiration = styled.input`
   border: none;
   border-radius: 5px;
   padding: 0 10px;
-  margin-bottom: 30px;
   transition: all 0.3s ease;
 
   &:focus {
@@ -146,6 +148,7 @@ const Expiration = styled.input`
 `;
 
 const Memo = styled.textarea`
+  height: 40px;
   resize: none;
   border: none;
   border-radius: 5px;

--- a/src/components/AddIngredientInfo.tsx
+++ b/src/components/AddIngredientInfo.tsx
@@ -2,12 +2,12 @@ import { styled } from 'styled-components';
 import { BasicButton } from './common/BasicButton';
 import { theme } from '../styles/theme';
 import { device } from '../styles/media';
-import type { Ingredient } from '../types/ingredientType';
+import type { AddIngredient } from '../types/ingredientType';
 
 interface Props {
   handleIngredientDetails: (index: number, field: string, value: string) => void;
   deleteAddedIngredient: (index: number) => void;
-  ingredientDetails: Ingredient[];
+  ingredientDetails: AddIngredient[];
 }
 
 export const AddIngredientInfo = ({

--- a/src/components/AddIngredientInfo.tsx
+++ b/src/components/AddIngredientInfo.tsx
@@ -10,18 +10,16 @@ interface Props {
   name: string;
   expiredAt: string;
   memo: string;
-  updateIngredientDetails: (index: number, field: string, value: string) => void;
+  handleIngredientDetails: (index: number, field: string, value: string) => void;
   index: number;
-  isSave: boolean;
 }
 
-export const IngredientInfo = ({
+export const AddIngredientInfo = ({
   name,
   expiredAt,
   memo,
-  updateIngredientDetails,
+  handleIngredientDetails,
   index,
-  isSave,
 }: Props) => {
   const [expanded, setExpanded] = useState<string | false>('');
 
@@ -30,11 +28,11 @@ export const IngredientInfo = ({
   };
 
   const handleExpiredAtChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    updateIngredientDetails(index, e.target.value, memo);
+    handleIngredientDetails(index, e.target.value, memo);
   };
 
   const handleMemoChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    updateIngredientDetails(index, expiredAt, e.target.value);
+    handleIngredientDetails(index, expiredAt, e.target.value);
   };
 
   return (
@@ -54,9 +52,7 @@ export const IngredientInfo = ({
                 <p> 유통기한</p>
               </Title>
               <Expiration
-                style={isSave ? { backgroundColor: '#f8f8f8' } : { backgroundColor: 'white' }}
                 required
-                readOnly={isSave}
                 type="date"
                 value={expiredAt}
                 onChange={handleExpiredAtChange}
@@ -66,13 +62,7 @@ export const IngredientInfo = ({
               <Title>
                 <p>간단 메모</p>
               </Title>
-              <Memo
-                style={isSave ? { backgroundColor: '#f8f8f8' } : { backgroundColor: 'white' }}
-                required
-                readOnly={isSave}
-                value={memo}
-                onChange={(e) => handleMemoChange(e)}
-              />
+              <Memo required value={memo} onChange={(e) => handleMemoChange(e)} />
             </Section>
             <BasicButton
               type="button"

--- a/src/components/MyIngredientList.tsx
+++ b/src/components/MyIngredientList.tsx
@@ -1,0 +1,45 @@
+import { useQuery } from '@tanstack/react-query';
+import { getIngredient } from '../api/ingredient/getIngredient';
+import { QUERY_KEY } from '../constants/queryKey';
+import styled from 'styled-components';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+
+import { Accordion, AccordionSummary } from '@mui/material';
+
+export const MyIngredientList = () => {
+  const { data } = useQuery({ queryKey: [QUERY_KEY.ADD_INGREDIENT], queryFn: getIngredient });
+  return (
+    <Container>
+      <p>재료 목록</p>
+      {data?.map((item, index) => (
+        <Accordion key={index}>
+          <AccordionSummary
+            aria-controls="panel1d-content"
+            id="panel1d-header"
+            expandIcon={<ExpandMoreIcon />}
+          >
+            <p>{item.name}</p>
+          </AccordionSummary>
+          <div>
+            <p>{item.expiredAt}</p>
+            <p>{item.memo}</p>
+          </div>
+          <div>
+            <button type="button">수정</button>
+            <button type="button">삭제</button>
+          </div>
+        </Accordion>
+      ))}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  margin-top: 10px;
+
+  & > p {
+    font-size: 20px;
+    font-weight: 600;
+    margin-top: 40px;
+  }
+`;

--- a/src/components/MyIngredientList.tsx
+++ b/src/components/MyIngredientList.tsx
@@ -4,6 +4,8 @@ import { QUERY_KEY } from '../constants/queryKey';
 import styled from 'styled-components';
 import { useState } from 'react';
 import type { Ingredient } from '../types/ingredientType';
+import { BasicButton } from './common/BasicButton';
+import { theme } from '../styles/theme';
 
 interface UpdatedItem {
   [key: number]: Ingredient;
@@ -17,6 +19,8 @@ export const MyIngredientList = () => {
   const [edit, setEdit] = useState<boolean>(false);
   const [deletedItems, setDeletedItems] = useState<number[]>([]);
   const [updatedItems, setUpdatedItems] = useState<UpdatedItem>({});
+
+  // console.log(updatedItems);
 
   const handleCheckboxChange = (id: number): void => {
     setDeletedItems((prevDeletedItems) =>
@@ -47,7 +51,7 @@ export const MyIngredientList = () => {
     }
   };
 
-  const saveChanges = (): void => {
+  const saveChanges = () => {
     const updatedItemsArray = Object.values(updatedItems).map((item) => ({
       id: item.id,
       name: item.name,
@@ -55,14 +59,15 @@ export const MyIngredientList = () => {
       memo: item.memo,
     }));
 
-    console.log({
+    const finalData = {
       deletedItems,
       updatedItems: updatedItemsArray,
-    });
+    };
 
-    // 이후 서버로 전송 로직
+    console.log(finalData);
 
-    // 상태 초기화
+    // TODO: 이후 서버로 전송 로직 추가
+
     setEdit(false);
     setDeletedItems([]);
     setUpdatedItems({});
@@ -72,50 +77,70 @@ export const MyIngredientList = () => {
     <Container>
       <TitleWrapper>
         <p>재료 목록</p>
-        {edit ? (
-          <button type="button" onClick={saveChanges}>
-            저장
-          </button>
-        ) : (
-          <button type="button" onClick={() => setEdit(true)}>
-            수정
-          </button>
-        )}
-      </TitleWrapper>
-
-      {data?.map((item) => (
-        <ItemWrapper key={item.id}>
-          <div>
-            <p>{item.name}</p>
-            {edit && (
-              <input
-                type="checkbox"
-                checked={deletedItems.includes(item.id)}
-                onChange={() => handleCheckboxChange(item.id)}
-              />
-            )}
-          </div>
+        <div>
           {edit ? (
-            <div>
-              <input
-                type="date"
-                defaultValue={item.expiredAt}
-                onChange={(e) => handleUpdate(item.id, 'expiredAt', e.target.value)}
-              />
-              <input
-                type="text"
-                defaultValue={item.memo}
-                onChange={(e) => handleUpdate(item.id, 'memo', e.target.value)}
-              />
-            </div>
+            <BasicButton
+              type="button"
+              onClick={saveChanges}
+              $bgcolor={theme.colors.orange}
+              $fontcolor={theme.colors.white}
+            >
+              저장
+            </BasicButton>
           ) : (
-            <div>
-              <p>{item.expiredAt}</p>
-              <p>{item.memo}</p>
-            </div>
+            <BasicButton
+              type="button"
+              $bgcolor={theme.colors.orange}
+              $fontcolor={theme.colors.white}
+              onClick={() => setEdit(true)}
+            >
+              수정
+            </BasicButton>
           )}
-        </ItemWrapper>
-      ))}
+        </div>
+      </TitleWrapper>
+      <GridContainer>
+        {data?.map((item) => (
+          <ItemWrapper key={item.id}>
+            <Item>
+              <Title>{item.name}</Title>
+              {edit && (
+                <DeleteCheck>
+                  <span>삭제</span>
+                  <StyledCheckbox
+                    type="checkbox"
+                    checked={deletedItems.includes(item.id)}
+                    onChange={() => handleCheckboxChange(item.id)}
+                  />
+                </DeleteCheck>
+              )}
+              {edit ? (
+                <InputWrapper>
+                  <p>유통기한</p>
+                  <DateInput
+                    type="date"
+                    defaultValue={item.expiredAt}
+                    onChange={(e) => handleUpdate(item.id, 'expiredAt', e.target.value)}
+                  />
+                  <p>간단 메모</p>
+                  <MemoInput
+                    type="text"
+                    defaultValue={item.memo}
+                    onChange={(e) => handleUpdate(item.id, 'memo', e.target.value)}
+                  />
+                </InputWrapper>
+              ) : (
+                <InfoWrapper>
+                  <span>유통기한</span>
+                  <p>{item.expiredAt}</p>
+                  <span>간단 메모</span>
+                  <p>{item.memo}</p>
+                </InfoWrapper>
+              )}
+            </Item>
+          </ItemWrapper>
+        ))}
+      </GridContainer>
     </Container>
   );
 };
@@ -135,7 +160,103 @@ const TitleWrapper = styled.div`
   }
 `;
 
+const GridContainer = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+`;
+
 const ItemWrapper = styled.div`
-  margin: 10px 0 10px 0;
-  padding: 14px;
+  padding: 3px;
+`;
+
+const Item = styled.div`
+  background-color: ${(props) => props.theme.colors.grayishWhite};
+  padding: 13px;
+  border-radius: 10px;
+`;
+
+const Title = styled.p`
+  font-size: 20px;
+  font-weight: 600;
+  margin-bottom: 15px;
+`;
+
+const DeleteCheck = styled.div`
+  margin-bottom: 10px;
+
+  & > span {
+    margin-right: 5px;
+  }
+`;
+
+const StyledCheckbox = styled.input.attrs({ type: 'checkbox' })`
+  cursor: pointer;
+  margin-right: 10px;
+  accent-color: ${(props) => props.theme.colors.navy};
+
+  &:hover {
+    opacity: 0.8;
+  }
+`;
+
+const InputWrapper = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  place-items: left;
+
+  & > p {
+    font-size: 14px;
+    color: ${(props) => props.theme.colors.darkGray};
+    font-weight: 600;
+    margin-bottom: 5px;
+  }
+`;
+
+const DateInput = styled.input`
+  max-width: 135px;
+  padding: 10px;
+  border: none;
+  border-radius: 8px;
+  margin-bottom: 12px;
+`;
+
+const MemoInput = styled.input`
+  width: 100%;
+  padding: 10px;
+  border: none;
+  border-radius: 8px;
+`;
+
+const InfoWrapper = styled.div`
+  & > span {
+    display: block;
+    margin-bottom: 2px;
+    font-size: 14px;
+    color: ${(props) => props.theme.colors.darkGray};
+    font-weight: 600;
+  }
+
+  & > p:nth-child(2) {
+    margin-bottom: 10px;
+  }
+
+  & > p:nth-child(4) {
+    max-width: 300px;
+    overflow-y: scroll;
+    overflow-y: hidden;
+
+    &::-webkit-scrollbar {
+      height: 8px;
+      background-color: ${(props) => props.theme.colors.lightGray};
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background-color: ${(props) => props.theme.colors.gray};
+      border-radius: 8px;
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+      background-color: ${(props) => props.theme.colors.darkGray};
+    }
+  }
 `;

--- a/src/components/MyIngredientList.tsx
+++ b/src/components/MyIngredientList.tsx
@@ -2,44 +2,140 @@ import { useQuery } from '@tanstack/react-query';
 import { getIngredient } from '../api/ingredient/getIngredient';
 import { QUERY_KEY } from '../constants/queryKey';
 import styled from 'styled-components';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { useState } from 'react';
+import type { Ingredient } from '../types/ingredientType';
 
-import { Accordion, AccordionSummary } from '@mui/material';
+interface UpdatedItem {
+  [key: number]: Ingredient;
+}
 
 export const MyIngredientList = () => {
-  const { data } = useQuery({ queryKey: [QUERY_KEY.ADD_INGREDIENT], queryFn: getIngredient });
+  const { data } = useQuery<Ingredient[]>({
+    queryKey: [QUERY_KEY.ADD_INGREDIENT],
+    queryFn: getIngredient,
+  });
+  const [edit, setEdit] = useState<boolean>(false);
+  const [deletedItems, setDeletedItems] = useState<number[]>([]);
+  const [updatedItems, setUpdatedItems] = useState<UpdatedItem>({});
+
+  const handleCheckboxChange = (id: number): void => {
+    setDeletedItems((prevDeletedItems) =>
+      prevDeletedItems.includes(id)
+        ? prevDeletedItems.filter((itemId) => itemId !== id)
+        : [...prevDeletedItems, id]
+    );
+
+    setUpdatedItems((prevUpdatedItems) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [id]: _, ...rest } = prevUpdatedItems;
+      return rest;
+    });
+  };
+
+  const handleUpdate = (id: number, field: 'expiredAt' | 'memo', value: string): void => {
+    if (!deletedItems.includes(id)) {
+      setUpdatedItems((prevItems) => {
+        const currentItem = data?.find((item) => item.id === id) ?? prevItems[id];
+        return {
+          ...prevItems,
+          [id]: {
+            ...currentItem,
+            [field]: value,
+          },
+        };
+      });
+    }
+  };
+
+  const saveChanges = (): void => {
+    const updatedItemsArray = Object.values(updatedItems).map((item) => ({
+      id: item.id,
+      name: item.name,
+      expiredAt: item.expiredAt,
+      memo: item.memo,
+    }));
+
+    console.log({
+      deletedItems,
+      updatedItems: updatedItemsArray,
+    });
+
+    // 이후 서버로 전송 로직
+
+    // 상태 초기화
+    setEdit(false);
+    setDeletedItems([]);
+    setUpdatedItems({});
+  };
+
   return (
     <Container>
-      <p>재료 목록</p>
-      {data?.map((item, index) => (
-        <Accordion key={index}>
-          <AccordionSummary
-            aria-controls="panel1d-content"
-            id="panel1d-header"
-            expandIcon={<ExpandMoreIcon />}
-          >
+      <TitleWrapper>
+        <p>재료 목록</p>
+        {edit ? (
+          <button type="button" onClick={saveChanges}>
+            저장
+          </button>
+        ) : (
+          <button type="button" onClick={() => setEdit(true)}>
+            수정
+          </button>
+        )}
+      </TitleWrapper>
+
+      {data?.map((item) => (
+        <ItemWrapper key={item.id}>
+          <div>
             <p>{item.name}</p>
-          </AccordionSummary>
-          <div>
-            <p>{item.expiredAt}</p>
-            <p>{item.memo}</p>
+            {edit && (
+              <input
+                type="checkbox"
+                checked={deletedItems.includes(item.id)}
+                onChange={() => handleCheckboxChange(item.id)}
+              />
+            )}
           </div>
-          <div>
-            <button type="button">수정</button>
-            <button type="button">삭제</button>
-          </div>
-        </Accordion>
+          {edit ? (
+            <div>
+              <input
+                type="date"
+                defaultValue={item.expiredAt}
+                onChange={(e) => handleUpdate(item.id, 'expiredAt', e.target.value)}
+              />
+              <input
+                type="text"
+                defaultValue={item.memo}
+                onChange={(e) => handleUpdate(item.id, 'memo', e.target.value)}
+              />
+            </div>
+          ) : (
+            <div>
+              <p>{item.expiredAt}</p>
+              <p>{item.memo}</p>
+            </div>
+          )}
+        </ItemWrapper>
       ))}
     </Container>
   );
 };
 
 const Container = styled.div`
-  margin-top: 10px;
+  margin-top: 60px;
+`;
 
+const TitleWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 20px 0 20px 0;
   & > p {
     font-size: 20px;
     font-weight: 600;
-    margin-top: 40px;
   }
+`;
+
+const ItemWrapper = styled.div`
+  margin: 10px 0 10px 0;
+  padding: 14px;
 `;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -8,6 +8,7 @@ export const END_POINTS = {
   MEMBERS: 'members',
   RECIPES: 'recipes',
   TOKEN: 'token/refresh',
+  INGREDIENT: 'ingredient',
 } as const;
 
 export const HTTP_STATUS_CODE = {} as const;

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -1,2 +1,2 @@
 // 이곳에 쿼리키 정의
-export const QUERY_KEY = { NEW_RECIPE: 'newRecipe' } as const;
+export const QUERY_KEY = { NEW_RECIPE: 'newRecipe', ADD_INGREDIENT: 'addIngredient' } as const;

--- a/src/mocks/db.json
+++ b/src/mocks/db.json
@@ -73,5 +73,6 @@
         }
       ]
     }
-  ]
+  ],
+  "ingredient": [{ "name": "당근", "expiration": "2020-09-09", "memo": "메모 당근" }]
 }

--- a/src/mocks/db.json
+++ b/src/mocks/db.json
@@ -74,5 +74,9 @@
       ]
     }
   ],
-  "ingredient": [{ "name": "당근", "expiration": "2020-09-09", "memo": "메모 당근" }]
+  "ingredient": [
+    { "name": "당근", "expiredAt": "2020-09-09", "memo": "메모 당근" },
+    { "name": "무", "expiredAt": "2026-09-12", "memo": "메모 무" },
+    { "name": "로즈마리", "expiredAt": "2020-10-09", "memo": "메모 로즈마리" }
+  ]
 }

--- a/src/mocks/db.json
+++ b/src/mocks/db.json
@@ -75,8 +75,8 @@
     }
   ],
   "ingredient": [
-    { "name": "당근", "expiredAt": "2020-09-09", "memo": "메모 당근" },
-    { "name": "무", "expiredAt": "2026-09-12", "memo": "메모 무" },
-    { "name": "로즈마리", "expiredAt": "2020-10-09", "memo": "메모 로즈마리" }
+    { "id": 1, "name": "당근", "expiredAt": "2020-09-09", "memo": "메모 당근" },
+    { "id": 2, "name": "무", "expiredAt": "2026-09-12", "memo": "메모 무" },
+    { "id": 3, "name": "로즈마리", "expiredAt": "2020-10-09", "memo": "메모 로즈마리" }
   ]
 }

--- a/src/pages/MyRefrigerator.tsx
+++ b/src/pages/MyRefrigerator.tsx
@@ -6,10 +6,8 @@ import { AddIngredientInfo } from '../components/AddIngredientInfo';
 import { BasicButton } from '../components/common/BasicButton';
 import { theme } from '../styles/theme';
 import { useEffect, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import type { Ingredient } from '../types/ingredientType';
-import { getIngredient } from '../api/ingredient/getIngredient';
-import { QUERY_KEY } from '../constants/queryKey';
+import { MyIngredientList } from '../components/MyIngredientList';
 
 export const MyRefrigerator = () => {
   const { addItemList, setAddItemList } = useSelectItem();
@@ -34,12 +32,20 @@ export const MyRefrigerator = () => {
     setIngredientDetails(newDetails);
   };
 
-  const handleSave = async () => {
-    console.log(ingredientDetails);
-    setIngredientDetails([]);
+  const deleteAddedIngredient = (index: number) => {
+    const newDetailList = ingredientDetails.filter((_, idx) => index !== idx);
+    const newItemList = addItemList.filter((_, idx) => index !== idx);
+    setIngredientDetails(newDetailList);
+    setAddItemList(newItemList);
   };
 
-  const { data } = useQuery({ queryKey: [QUERY_KEY.ADD_INGREDIENT], queryFn: getIngredient });
+  const handleSave = async () => {
+    console.log('저장될 리스트', ingredientDetails);
+
+    // TODO: 여기에 서버에 보내는 로직을 추가
+    setIngredientDetails([]);
+    setAddItemList([]);
+  };
 
   return (
     <>
@@ -47,26 +53,24 @@ export const MyRefrigerator = () => {
       <Container>
         <IngredientSearchForm addItemList={addItemList} setAddItemList={setAddItemList} />
         <Wrapper>
-          {ingredientDetails.map((ingredient, index) => (
-            <AddIngredientInfo
-              key={index}
-              name={ingredient.name}
-              expiredAt={ingredient.expiredAt}
-              memo={ingredient.memo}
-              handleIngredientDetails={handleIngredientDetails}
-              index={index}
-            />
-          ))}
-        </Wrapper>
+          <AddIngredientInfo
+            ingredientDetails={ingredientDetails}
+            handleIngredientDetails={handleIngredientDetails}
+            deleteAddedIngredient={deleteAddedIngredient}
+          />
 
-        <BasicButton
-          type="button"
-          $bgcolor={theme.colors.orange}
-          $fontcolor={theme.colors.white}
-          onClick={handleSave}
-        >
-          저장
-        </BasicButton>
+          {ingredientDetails.length > 0 && (
+            <BasicButton
+              type="button"
+              $bgcolor={theme.colors.orange}
+              $fontcolor={theme.colors.white}
+              onClick={handleSave}
+            >
+              재료 추가
+            </BasicButton>
+          )}
+        </Wrapper>
+        <MyIngredientList />
       </Container>
     </>
   );
@@ -87,4 +91,8 @@ const Wrapper = styled.div`
   grid-template-columns: 1fr;
   place-items: center;
   gap: 5px;
+
+  & > button {
+    margin-top: 20px;
+  }
 `;

--- a/src/pages/MyRefrigerator.tsx
+++ b/src/pages/MyRefrigerator.tsx
@@ -6,12 +6,12 @@ import { AddIngredientInfo } from '../components/AddIngredientInfo';
 import { BasicButton } from '../components/common/BasicButton';
 import { theme } from '../styles/theme';
 import { useEffect, useState } from 'react';
-import type { Ingredient } from '../types/ingredientType';
+import type { AddIngredient } from '../types/ingredientType';
 import { MyIngredientList } from '../components/MyIngredientList';
 
 export const MyRefrigerator = () => {
   const { addItemList, setAddItemList } = useSelectItem();
-  const [ingredientDetails, setIngredientDetails] = useState<Ingredient[]>(
+  const [ingredientDetails, setIngredientDetails] = useState<AddIngredient[]>(
     addItemList.map((name) => ({ name, expiredAt: '', memo: '' }))
   );
 

--- a/src/pages/MyRefrigerator.tsx
+++ b/src/pages/MyRefrigerator.tsx
@@ -58,7 +58,6 @@ export const MyRefrigerator = () => {
             handleIngredientDetails={handleIngredientDetails}
             deleteAddedIngredient={deleteAddedIngredient}
           />
-
           {ingredientDetails.length > 0 && (
             <BasicButton
               type="button"

--- a/src/pages/MyRefrigerator.tsx
+++ b/src/pages/MyRefrigerator.tsx
@@ -2,26 +2,22 @@ import { styled } from 'styled-components';
 import { BasicTitle } from '../components/common/BasicTitle';
 import { useSelectItem } from '../hooks/useSelectItem';
 import { IngredientSearchForm } from '../components/IngredientSearchForm';
-import { IngredientInfo } from '../components/IngredientInfo';
+import { AddIngredientInfo } from '../components/AddIngredientInfo';
 import { BasicButton } from '../components/common/BasicButton';
 import { theme } from '../styles/theme';
 import { useEffect, useState } from 'react';
-
-interface Ingredient {
-  name: string;
-  expiredAt: string;
-  memo: string;
-}
+import { useQuery } from '@tanstack/react-query';
+import type { Ingredient } from '../types/ingredientType';
+import { getIngredient } from '../api/ingredient/getIngredient';
+import { QUERY_KEY } from '../constants/queryKey';
 
 export const MyRefrigerator = () => {
   const { addItemList, setAddItemList } = useSelectItem();
   const [ingredientDetails, setIngredientDetails] = useState<Ingredient[]>(
     addItemList.map((name) => ({ name, expiredAt: '', memo: '' }))
   );
-  const [isSave, setIsSave] = useState(false);
 
   useEffect(() => {
-    setIsSave(false);
     const newItems = addItemList.filter(
       (item) => !ingredientDetails.some((detail) => detail.name === item)
     );
@@ -32,15 +28,18 @@ export const MyRefrigerator = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [addItemList]);
 
-  const updateIngredientDetails = (index: number, expiredAt: string, memo: string) => {
+  const handleIngredientDetails = (index: number, expiredAt: string, memo: string) => {
     const newDetails = [...ingredientDetails];
     newDetails[index] = { ...newDetails[index], expiredAt, memo };
     setIngredientDetails(newDetails);
   };
 
   const handleSave = async () => {
-    setIsSave(!isSave);
+    console.log(ingredientDetails);
+    setIngredientDetails([]);
   };
+
+  const { data } = useQuery({ queryKey: [QUERY_KEY.ADD_INGREDIENT], queryFn: getIngredient });
 
   return (
     <>
@@ -49,36 +48,25 @@ export const MyRefrigerator = () => {
         <IngredientSearchForm addItemList={addItemList} setAddItemList={setAddItemList} />
         <Wrapper>
           {ingredientDetails.map((ingredient, index) => (
-            <IngredientInfo
+            <AddIngredientInfo
               key={index}
               name={ingredient.name}
               expiredAt={ingredient.expiredAt}
               memo={ingredient.memo}
-              updateIngredientDetails={updateIngredientDetails}
+              handleIngredientDetails={handleIngredientDetails}
               index={index}
-              isSave={isSave}
             />
           ))}
         </Wrapper>
-        {isSave ? (
-          <BasicButton
-            type="button"
-            $bgcolor={theme.colors.orange}
-            $fontcolor={theme.colors.white}
-            onClick={handleSave}
-          >
-            수정
-          </BasicButton>
-        ) : (
-          <BasicButton
-            type="button"
-            $bgcolor={theme.colors.orange}
-            $fontcolor={theme.colors.white}
-            onClick={handleSave}
-          >
-            저장
-          </BasicButton>
-        )}
+
+        <BasicButton
+          type="button"
+          $bgcolor={theme.colors.orange}
+          $fontcolor={theme.colors.white}
+          onClick={handleSave}
+        >
+          저장
+        </BasicButton>
       </Container>
     </>
   );

--- a/src/types/ingredientType.ts
+++ b/src/types/ingredientType.ts
@@ -1,5 +1,9 @@
-export interface Ingredient {
+export interface AddIngredient {
   name: string;
   expiredAt: string;
   memo: string;
+}
+
+export interface Ingredient extends AddIngredient {
+  id: number;
 }

--- a/src/types/ingredientType.ts
+++ b/src/types/ingredientType.ts
@@ -1,0 +1,5 @@
+export interface Ingredient {
+  name: string;
+  expiredAt: string;
+  memo: string;
+}


### PR DESCRIPTION
## 작업내용
- 재료를 검색하여 유통기한과 메모를 작성하는 부분을 따로 분리 했습니다.
- 재료 추가를 누르면 서버로 전송되며 아래 재료 목록 리스트에 작성한 재료가 추가되게 됩니다.
- 현재 로직상으로는 목서버에 직접 추가시키진 않습니다.
![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/107461545/65ef3676-cdb8-47d3-9fe8-35d9b0a58a23)
- 수정버튼을 누르면 아래와 같이 유저가 가지고 있는 재료목록을 수정할 수 있습니다.
- 서버에 일괄적으로 보내야하기 때문에 일괄수정 형식으로 UI를 구성하였습니다.
```javascript
{
deletedItem:[1,2]
updatedItem: [{'id':1, 'name':'당근','date':'2020-01-02', 'description':'수정된 설명'}]
}
```
- 현재 삭제된 데이터와 수정된 데이터를 서버에 보내기 직전 로직까지만 작성한 상황입니다.
- 현재는 저장을 눌러도 목서버의 데이터 내용이 바뀌진 않습니다.
![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/107461545/d1297836-07db-43cb-b4a2-3dab78eb7954)

## 작업목적
- 나의 냉장고 재료 수정 삭제 방식 변경에 따른 req 전송 데이터 형식 수정하기 위함
