### PR TITLE
냉장고를부탁해 #66 레시피 상세페이지 데이터 연동

### DIFF
--- a/src/api/recipe.ts
+++ b/src/api/recipe.ts
@@ -12,13 +12,9 @@ export const getNewRecipe = async () => {
   }
 };
 
-export const getDetailRecipe = async () => {
+export const getDetailRecipe = async (recipeId: string) => {
   try {
-    const result = await axiosDefault.get(END_POINTS.RECIPES, {
-      params: {
-        recipeId: 1,
-      },
-    });
+    const result = await axiosDefault.get(`${END_POINTS.RECIPES}/${recipeId}`);
     return result.data;
   } catch (error) {
     throw new Error(`${error}`);

--- a/src/api/recipe.ts
+++ b/src/api/recipe.ts
@@ -11,3 +11,16 @@ export const getNewRecipe = async () => {
     throw new Error(`${error}`);
   }
 };
+
+export const getDetailRecipe = async () => {
+  try {
+    const result = await axiosDefault.get(END_POINTS.RECIPES, {
+      params: {
+        recipeId: 1,
+      },
+    });
+    return result.data;
+  } catch (error) {
+    throw new Error(`${error}`);
+  }
+};

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -1,2 +1,6 @@
 // 이곳에 쿼리키 정의
-export const QUERY_KEY = { NEW_RECIPE: 'newRecipe', ADD_INGREDIENT: 'addIngredient' } as const;
+export const QUERY_KEY = {
+  NEW_RECIPE: 'newRecipe',
+  DETAIL_RECIPE: 'detailRecipe',
+  ADD_INGREDIENT: 'addIngredient',
+} as const;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 import { BasicTitle } from '../components/common/BasicTitle';
 import { Suspense } from 'react';
-import { CardList } from '../components/CardList';
 import { FallBack } from '../components/common/FallBack';
 import { Carousel } from '../components/common/Carousel';
+import { CardList } from '../components/common/CardList';
 
 export const Index = () => {
   const testImage = [

--- a/src/pages/RecipeView.tsx
+++ b/src/pages/RecipeView.tsx
@@ -2,8 +2,8 @@ import styled from 'styled-components';
 import { BasicButton } from '../components/common/BasicButton';
 import { BasicTitle } from '../components/common/BasicTitle';
 import { RiBookmarkLine } from 'react-icons/ri';
-import { IoHeartOutline } from 'react-icons/io5';
-import { PiSiren } from 'react-icons/pi';
+import { BsExclamationSquare } from 'react-icons/bs';
+import { PiSiren, PiCookingPotDuotone, PiEyeDuotone } from 'react-icons/pi';
 import { RecipeReviewList } from '../components/pages/recipe/RecipeReviewList';
 import { useState } from 'react';
 import { ConfirmModal } from '../components/common/ConfirmModal';
@@ -11,7 +11,8 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { getDetailRecipe } from '../api/recipe';
 import { QUERY_KEY } from '../constants/queryKey';
-import axios from 'axios';
+import { formatDate } from '../utils/formatDate';
+import type { RecipeStep } from '../types/recipeType';
 
 export const RecipeView = () => {
   const navigation = useNavigate();
@@ -30,30 +31,42 @@ export const RecipeView = () => {
   const { data } = useQuery({
     queryKey: [QUERY_KEY.DETAIL_RECIPE],
     queryFn: () => getDetailRecipe(recipeId),
+    select: (data) => data.data,
   });
 
+  // TODO : 더미 데이터 이미지 없음 -> 실 데이터 가져올 때 이미지만 연동하면 됨
   return (
     <RecipeViewContainer>
       <div className="recipe-detail">
         <div className="header">
-          <BasicTitle title="존맛탱 마약 떡볶이 만들기" />
-          <RiBookmarkLine />
+          <BasicTitle title={data?.title} />
         </div>
         <div className="post-info">
           <div>
-            <span className="name">띠띠</span>
-            <span className="date">2024-01-02</span>
-            <span className="count">조회수 10</span>
+            <span className="name">{data?.author.nickname}</span>
+            <span className="date">{formatDate(data?.createdAt)}</span>
+            <span className="count">
+              <span>
+                <PiEyeDuotone /> {data?.viewCount}
+              </span>
+              <span>
+                <PiCookingPotDuotone />
+                {data?.reviewCount}
+              </span>
+            </span>
           </div>
           <div>
             <div className="icons">
               <span>
-                <IoHeartOutline />
+                <RiBookmarkLine />
               </span>
-              <span>2</span>
+              <span>{data?.bookmarkCount}</span>
             </div>
-            <div>
-              <PiSiren />
+            <div className="icons">
+              <span>
+                <PiSiren />
+              </span>
+              <span>{data?.reportCount}</span>
             </div>
           </div>
         </div>
@@ -61,27 +74,24 @@ export const RecipeView = () => {
           <div className="thumbnail">
             <img src="https://img.siksinhot.com/place/1515555441230703.jpg" alt="썸네일" />
           </div>
-          <div className="step">
-            <img
-              src="https://www.goodtraemall.co.kr/shopimages/cepa0001/006001000017.jpg?1670307118"
-              alt="단계별 레시피"
-            />
-            <div>1. 떡을 야무지게 불립니다.</div>
-          </div>
-          <div className="step">
-            <img
-              src="https://www.goodtraemall.co.kr/shopimages/cepa0001/006001000017.jpg?1670307118"
-              alt="단계별 레시피"
-            />
-            <div>2. 떡을 야무지게 불립니다.</div>
-          </div>
-          <div className="step">
-            <img
-              src="https://www.goodtraemall.co.kr/shopimages/cepa0001/006001000017.jpg?1670307118"
-              alt="단계별 레시피"
-            />
-            <div>3. 떡을 야무지게 불립니다.</div>
-          </div>
+
+          {data?.recipeSteps.map((step: RecipeStep) => {
+            return (
+              <div className="step" key={step.stepNo}>
+                <img
+                  src="https://www.goodtraemall.co.kr/shopimages/cepa0001/006001000017.jpg?1670307118"
+                  alt="단계별 레시피"
+                />
+                <div>{step.stepContents}</div>
+                {step.stepTip && (
+                  <div className="tip">
+                    <BsExclamationSquare />
+                    tip : {step.stepTip}
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
         <BasicButton
           $bgcolor="#ff8527"
@@ -151,6 +161,13 @@ const RecipeViewContainer = styled.div`
 
     .count {
       color: ${(props) => props.theme.colors.darkGray};
+      display: flex;
+      gap: 12px;
+
+      & > span {
+        display: flex;
+        gap: 3px;
+      }
     }
   }
 
@@ -176,11 +193,23 @@ const RecipeViewContainer = styled.div`
       align-items: center;
       gap: 12px;
       grid-template-columns: 30% 1fr;
+      margin-top: 36px;
 
       img {
         width: 100%;
         height: auto;
         display: block;
+      }
+
+      .tip {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        color: ${(props) => props.theme.colors.darkGray};
+      }
+
+      svg {
+        color: ${(props) => props.theme.colors.orange};
       }
     }
   }

--- a/src/pages/RecipeView.tsx
+++ b/src/pages/RecipeView.tsx
@@ -86,9 +86,7 @@ export const RecipeView = () => {
             <span className="chips">
               {data?.recipeIngredients.map((ingredient: Ingredient) => {
                 return (
-                  <>
-                    <Chip label={`${ingredient.name} ${ingredient.amount}`} key={ingredient.name} />
-                  </>
+                  <Chip label={`${ingredient.name} ${ingredient.amount}`} key={ingredient.name} />
                 );
               })}
             </span>

--- a/src/pages/RecipeView.tsx
+++ b/src/pages/RecipeView.tsx
@@ -7,10 +7,16 @@ import { PiSiren } from 'react-icons/pi';
 import { RecipeReviewList } from '../components/pages/recipe/RecipeReviewList';
 import { useState } from 'react';
 import { ConfirmModal } from '../components/common/ConfirmModal';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { getDetailRecipe } from '../api/recipe';
+import { QUERY_KEY } from '../constants/queryKey';
+import axios from 'axios';
 
 export const RecipeView = () => {
   const navigation = useNavigate();
+  const { pathname } = useLocation();
+  const recipeId = pathname.split('/').pop() || '';
   const [cookingCompletion, setCookingCompletion] = useState(false);
 
   const onAgree = () => {
@@ -20,6 +26,11 @@ export const RecipeView = () => {
   const handleCookingCompletion = (isComplete: boolean) => {
     setCookingCompletion(isComplete);
   };
+
+  const { data } = useQuery({
+    queryKey: [QUERY_KEY.DETAIL_RECIPE],
+    queryFn: () => getDetailRecipe(recipeId),
+  });
 
   return (
     <RecipeViewContainer>

--- a/src/pages/RecipeView.tsx
+++ b/src/pages/RecipeView.tsx
@@ -4,6 +4,7 @@ import { BasicTitle } from '../components/common/BasicTitle';
 import { RiBookmarkLine } from 'react-icons/ri';
 import { BsExclamationSquare } from 'react-icons/bs';
 import { PiSiren, PiCookingPotDuotone, PiEyeDuotone } from 'react-icons/pi';
+import { GiCook } from 'react-icons/gi';
 import { RecipeReviewList } from '../components/pages/recipe/RecipeReviewList';
 import { useState } from 'react';
 import { ConfirmModal } from '../components/common/ConfirmModal';
@@ -12,7 +13,8 @@ import { useQuery } from '@tanstack/react-query';
 import { getDetailRecipe } from '../api/recipe';
 import { QUERY_KEY } from '../constants/queryKey';
 import { formatDate } from '../utils/formatDate';
-import type { RecipeStep } from '../types/recipeType';
+import { Chip } from '@mui/material';
+import type { Ingredient, RecipeSteps } from '../types/recipeType';
 
 export const RecipeView = () => {
   const navigation = useNavigate();
@@ -74,8 +76,25 @@ export const RecipeView = () => {
           <div className="thumbnail">
             <img src="https://img.siksinhot.com/place/1515555441230703.jpg" alt="썸네일" />
           </div>
+          <p className="summary">{data?.summary}</p>
 
-          {data?.recipeSteps.map((step: RecipeStep) => {
+          <div className="ingredient">
+            <h3>
+              <GiCook />
+              재료
+            </h3>
+            <span className="chips">
+              {data?.recipeIngredients.map((ingredient: Ingredient) => {
+                return (
+                  <>
+                    <Chip label={`${ingredient.name} ${ingredient.amount}`} key={ingredient.name} />
+                  </>
+                );
+              })}
+            </span>
+          </div>
+
+          {data?.recipeSteps.map((step: RecipeSteps) => {
             return (
               <div className="step" key={step.stepNo}>
                 <img
@@ -172,6 +191,31 @@ const RecipeViewContainer = styled.div`
   }
 
   .recipe-step {
+    .ingredient {
+      border: 1px solid ${(props) => props.theme.colors.lightGray};
+      border-radius: 12px;
+      padding: 24px;
+      margin-top: 24px;
+
+      h3 {
+        color: ${(props) => props.theme.colors.black};
+        margin: 0 0 12px 4px;
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+
+      .chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+    }
+
+    .summary {
+      padding: 24px 0;
+    }
+
     .thumbnail {
       margin: 12px 0;
       width: 100%;

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -4,7 +4,7 @@ import { BasicInput } from '../components/common/BasicInput';
 import { BasicButton } from '../components/common/BasicButton';
 import { Link } from 'react-router-dom';
 import { useMutation } from '@tanstack/react-query';
-import { signUp } from '../api/auth/signUp';
+import { signUp } from '../api/auth';
 
 export const SignUp = () => {
   const { mutate } = useMutation({

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -5,7 +5,7 @@ export const theme = {
     navy: '#003046',
     blue: '#009eba',
     sky: '#85cae4',
-    black: '#000000',
+    black: '#242424',
     darkGray: '#636773',
     gray: '#b3b4ba',
     lightGray: '#e1e2e3',

--- a/src/types/recipeType.ts
+++ b/src/types/recipeType.ts
@@ -12,3 +12,10 @@ export interface Recipe {
   createdAt: string;
   member: Member;
 }
+
+export interface RecipeStep {
+  stepContents: string;
+  stepImageUrl: string;
+  stepNo: number;
+  stepTip: string;
+}

--- a/src/types/recipeType.ts
+++ b/src/types/recipeType.ts
@@ -13,9 +13,32 @@ export interface Recipe {
   member: Member;
 }
 
-export interface RecipeStep {
-  stepContents: string;
-  stepImageUrl: string;
-  stepNo: number;
-  stepTip: string;
+export interface DetailRecipe {
+  author: {
+    id: number;
+    nickname: string;
+    role: string;
+  };
+  bookmarkCount: number;
+  createAt: string;
+  id: number;
+  recipeImageUrl: string;
+  recipeIngredients: {
+    name: string;
+    amount: string;
+  };
+  recipeSteps: {
+    stepContents: string;
+    stepImageUrl: string;
+    stepNo: number;
+    stepTip: string;
+  };
+  reportCount: number;
+  reviewCount: number;
+  summary: string;
+  title: string;
+  viewCount: number;
 }
+
+export type RecipeSteps = DetailRecipe['recipeSteps'];
+export type Ingredient = DetailRecipe['recipeIngredients'];

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,12 @@
+export const formatDate = (originalDateString: string) => {
+  const originalDate = new Date(originalDateString);
+  const year = originalDate.getFullYear();
+  const month = String(originalDate.getMonth() + 1).padStart(2, '0');
+  const day = String(originalDate.getDate()).padStart(2, '0');
+  const hours = String(originalDate.getHours()).padStart(2, '0');
+  const minutes = String(originalDate.getMinutes()).padStart(2, '0');
+
+  const formattedDate = `${year}-${month}-${day} ${hours}:${minutes}`;
+
+  return formattedDate;
+};


### PR DESCRIPTION
## 작업 목적
- 특정 레시피 상세 데이터 연동

## 작업 내용
- 서버 데이터 연동
- 디테일한 스타일 수정(아이콘 추가, 리뷰 수, 스크랩 수, 신고 수, step tip 추가)
-  // TODO : 더미 데이터 이미지 없음 -> 실 데이터 넣어주면 이미지만 연동하면 됨

![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/85798544/d96dfb9e-c8b0-4140-8438-462148cecb83)
![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/85798544/58ea6d65-97cf-4685-b698-1c87b5282baa)


## 관련된 이슈, 커밋, PR
- #66 
- #39 