### PR TITLE
냉장고를 부탁해 #70 이메일 로그인 기능 구현

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -7,9 +7,23 @@ interface SignUpProps {
   password: string;
 }
 
+interface SignInProps {
+  email: string;
+  password: string;
+}
+
 export const fetchSignUp = async (params: SignUpProps) => {
   const { data } = await axiosDefault.post(END_POINTS.JOIN, params);
   return data;
+};
+
+export const fetchSignIn = async (params: SignInProps) => {
+  const { data, headers } = await axiosDefault.post(END_POINTS.LOGIN, params);
+
+  const token = headers['access-token'];
+  const refreshToken = headers['refresh-token'];
+
+  return { data, token, refreshToken };
 };
 
 export const emailAuth = async (code: string) => {

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -2,6 +2,7 @@ import type { AxiosError, InternalAxiosRequestConfig } from 'axios';
 import { ACCESS_TOKEN_KEY, END_POINTS, ROOT_URL } from '../constants/api';
 import { axiosAuth } from './axiosInstance';
 import type { Token } from '../types/tokenType';
+import { getRefreshToken } from '../utils/getRefreshToken';
 
 export const checkAndSetToken = (config: InternalAxiosRequestConfig) => {
   if (!config.headers || config.headers.Authorization) return config;
@@ -25,7 +26,8 @@ export const handleTokenError = async (error: AxiosError) => {
 
   if (error.response && error.response.status === 401) {
     try {
-      const response = await axiosAuth.post<Token>(END_POINTS.TOKEN);
+      const refreshToken = getRefreshToken('refreshToken');
+      const response = await axiosAuth.post<Token>(END_POINTS.TOKEN, refreshToken);
 
       if (response.status === 200) {
         const { accessToken } = response.data;

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -30,7 +30,8 @@ export const handleTokenError = async (error: AxiosError) => {
       const response = await axiosAuth.post<Token>(END_POINTS.TOKEN, refreshToken);
 
       if (response.status === 200) {
-        const { accessToken } = response.data;
+        const header = response.headers;
+        const accessToken = header['access-token'];
 
         originalRequest.headers.Authorization = accessToken;
 

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -32,9 +32,9 @@ export const handleTokenError = async (error: AxiosError) => {
       if (response.status === 200) {
         const { accessToken } = response.data;
 
-        originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+        originalRequest.headers.Authorization = accessToken;
 
-        sessionStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+        sessionStorage.setItem(ACCESS_TOKEN_KEY, accessToken.replace('Bearer', ''));
 
         return axiosAuth(originalRequest);
       }

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -1,7 +1,6 @@
 import type { AxiosError, InternalAxiosRequestConfig } from 'axios';
 import { ACCESS_TOKEN_KEY, END_POINTS, ROOT_URL } from '../constants/api';
 import { axiosAuth } from './axiosInstance';
-import type { Token } from '../types/tokenType';
 import { getRefreshToken } from '../utils/getRefreshToken';
 
 export const checkAndSetToken = (config: InternalAxiosRequestConfig) => {
@@ -27,7 +26,7 @@ export const handleTokenError = async (error: AxiosError) => {
   if (error.response && error.response.status === 401) {
     try {
       const refreshToken = getRefreshToken('refreshToken');
-      const response = await axiosAuth.post<Token>(END_POINTS.TOKEN, refreshToken);
+      const response = await axiosAuth.post(END_POINTS.TOKEN, refreshToken);
 
       if (response.status === 200) {
         const header = response.headers;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -8,7 +8,7 @@ import { BasicInput } from '../common/BasicInput';
 import { BasicButton } from '../common/BasicButton';
 import { currentCategoryAtom } from '../../store/menu';
 import { TbBellFilled } from 'react-icons/tb';
-import { ACCESS_TOKEN_KEY } from '../../constants/api';
+import { ACCESS_TOKEN_KEY, USER_STATUS_KEY } from '../../constants/api';
 
 export const Header = () => {
   const isLogin = !!sessionStorage.getItem(ACCESS_TOKEN_KEY);
@@ -34,6 +34,7 @@ export const Header = () => {
   const handleLogOut = () => {
     navigation('/');
     sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+    sessionStorage.removeItem(USER_STATUS_KEY);
     document.cookie = `refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
     // eslint-disable-next-line no-alert
     alert('로그아웃 되었습니다.');

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -3,14 +3,25 @@ import { useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { SideBar } from '../common/SideBar';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { BasicInput } from '../common/BasicInput';
 import { BasicButton } from '../common/BasicButton';
 import { currentCategoryAtom } from '../../store/menu';
 import { TbBellFilled } from 'react-icons/tb';
+import { ACCESS_TOKEN_KEY } from '../../constants/api';
 
 export const Header = () => {
+  const isLogin = !!sessionStorage.getItem(ACCESS_TOKEN_KEY);
   const [sideBar, setSideBar] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(isLogin);
+
+  useEffect(() => {
+    if (isLogin) {
+      setIsLoggedIn(true);
+    } else {
+      setIsLoggedIn(false);
+    }
+  }, [isLogin]);
 
   const navigation = useNavigate();
   const setCurrentCategory = useSetRecoilState(currentCategoryAtom);
@@ -20,11 +31,31 @@ export const Header = () => {
     setCurrentCategory('');
   };
 
+  const handleLogOut = () => {
+    navigation('/');
+    sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+    // eslint-disable-next-line no-alert
+    alert('로그아웃 되었습니다.');
+  };
+
   return (
     <Container>
       <Wrapper>
         <BasicInput id="text" type="email" placeholder="레시피를 검색해 주세요." />
-        <div>
+        {isLoggedIn ? (
+          <>
+            <BasicButton
+              onClick={handleLogOut}
+              type="button"
+              $bgcolor="#FF8527"
+              $fontcolor="#fff"
+              $hoverbgcolor="#ff750c"
+            >
+              로그아웃
+            </BasicButton>
+            <TbBellFilled onClick={() => setSideBar(true)} />
+          </>
+        ) : (
           <BasicButton
             onClick={handleLogin}
             type="button"
@@ -34,8 +65,7 @@ export const Header = () => {
           >
             로그인
           </BasicButton>
-        </div>
-        <TbBellFilled onClick={() => setSideBar(true)} />
+        )}
       </Wrapper>
       {sideBar && <SideBar isOpen={sideBar} handleSidebar={() => setSideBar(false)} />}
     </Container>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -34,6 +34,7 @@ export const Header = () => {
   const handleLogOut = () => {
     navigation('/');
     sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+    document.cookie = `refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
     // eslint-disable-next-line no-alert
     alert('로그아웃 되었습니다.');
   };

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,30 +1,22 @@
 import { useNavigate } from 'react-router';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { SideBar } from '../common/SideBar';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { BasicInput } from '../common/BasicInput';
 import { BasicButton } from '../common/BasicButton';
 import { currentCategoryAtom } from '../../store/menu';
 import { TbBellFilled } from 'react-icons/tb';
 import { ACCESS_TOKEN_KEY, USER_STATUS_KEY } from '../../constants/api';
+import { AuthStateAtom } from '../../store/auth';
 
 export const Header = () => {
-  const isLogin = !!sessionStorage.getItem(ACCESS_TOKEN_KEY);
   const [sideBar, setSideBar] = useState(false);
-  const [isLoggedIn, setIsLoggedIn] = useState(isLogin);
-
-  useEffect(() => {
-    if (isLogin) {
-      setIsLoggedIn(true);
-    } else {
-      setIsLoggedIn(false);
-    }
-  }, [isLogin]);
 
   const navigation = useNavigate();
   const setCurrentCategory = useSetRecoilState(currentCategoryAtom);
+  const [authState, setAuthState] = useRecoilState(AuthStateAtom);
 
   const handleLogin = () => {
     navigation('/signin');
@@ -33,9 +25,12 @@ export const Header = () => {
 
   const handleLogOut = () => {
     navigation('/');
+
     sessionStorage.removeItem(ACCESS_TOKEN_KEY);
     sessionStorage.removeItem(USER_STATUS_KEY);
+
     document.cookie = `refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+    setAuthState(false);
     // eslint-disable-next-line no-alert
     alert('로그아웃 되었습니다.');
   };
@@ -44,7 +39,7 @@ export const Header = () => {
     <Container>
       <Wrapper>
         <BasicInput id="text" type="email" placeholder="레시피를 검색해 주세요." />
-        {isLoggedIn ? (
+        {authState ? (
           <>
             <BasicButton
               onClick={handleLogOut}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -8,14 +8,17 @@ import { BasicInput } from '../common/BasicInput';
 import { BasicButton } from '../common/BasicButton';
 import { currentCategoryAtom } from '../../store/menu';
 import { TbBellFilled } from 'react-icons/tb';
-import { ACCESS_TOKEN_KEY, USER_STATUS_KEY } from '../../constants/api';
-import { AuthStateAtom } from '../../store/auth';
+import { ACCESS_TOKEN_KEY, USER_NICKNAME_KEY, USER_STATUS_KEY } from '../../constants/api';
+import { AuthStateAtom, NickNameAtom } from '../../store/auth';
+import { device } from '../../styles/media';
 
 export const Header = () => {
   const [sideBar, setSideBar] = useState(false);
 
   const navigation = useNavigate();
+
   const setCurrentCategory = useSetRecoilState(currentCategoryAtom);
+  const [userNickName, setUserNickName] = useRecoilState(NickNameAtom);
   const [authState, setAuthState] = useRecoilState(AuthStateAtom);
 
   const handleLogin = () => {
@@ -28,9 +31,11 @@ export const Header = () => {
 
     sessionStorage.removeItem(ACCESS_TOKEN_KEY);
     sessionStorage.removeItem(USER_STATUS_KEY);
+    sessionStorage.removeItem(USER_NICKNAME_KEY);
 
     document.cookie = `refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
     setAuthState(false);
+    setUserNickName('');
     // eslint-disable-next-line no-alert
     alert('로그아웃 되었습니다.');
   };
@@ -63,6 +68,13 @@ export const Header = () => {
             로그인
           </BasicButton>
         )}
+        {userNickName && (
+          <Nickname>
+            <StyledLink to="/mypage">
+              <span>{`${userNickName}님 환영합니다.`}</span>
+            </StyledLink>
+          </Nickname>
+        )}
       </Wrapper>
       {sideBar && <SideBar isOpen={sideBar} handleSidebar={() => setSideBar(false)} />}
     </Container>
@@ -81,6 +93,7 @@ const Container = styled.header`
 `;
 
 const Wrapper = styled.div`
+  position: relative;
   display: grid;
   grid-template-columns: 1fr auto auto;
   align-items: center;
@@ -101,9 +114,25 @@ const Wrapper = styled.div`
     color: ${(props) => props.theme.colors.darkGray};
     cursor: pointer;
   }
+
+  @media ${device.mobile} {
+    padding: 10px;
+
+    button {
+      width: 70px;
+    }
+  }
 `;
 
 export const StyledLink = styled(Link)`
   text-decoration: none;
   color: inherit;
+`;
+
+const Nickname = styled.p`
+  position: absolute;
+  font-size: 14px;
+
+  bottom: -27px;
+  left: 6px;
 `;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -8,6 +8,8 @@ export const ACCESS_TOKEN_KEY = 'refrigeKey' as const; // TODO: 임시 로컬스
 
 export const USER_STATUS_KEY = 'userState' as const;
 
+export const USER_NICKNAME_KEY = 'nickName';
+
 export const END_POINTS = {
   MEMBERS: 'members',
   RECIPES: 'recipes',

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -6,6 +6,8 @@ export const ROOT_URL = 'http://localhost:5173/';
 
 export const ACCESS_TOKEN_KEY = 'refrigeKey' as const; // TODO: 임시 로컬스토리지 key 임으로 추후 합의 후 변경 필요
 
+export const USER_STATUS_KEY = 'userState' as const;
+
 export const END_POINTS = {
   MEMBERS: 'members',
   RECIPES: 'recipes',

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -9,7 +9,7 @@ import { Controller, useForm } from 'react-hook-form';
 import { useMutation } from '@tanstack/react-query';
 import { fetchSignIn } from '../api/auth';
 import type { AxiosError } from 'axios';
-import { ACCESS_TOKEN_KEY } from '../constants/api';
+import { ACCESS_TOKEN_KEY, USER_STATUS_KEY } from '../constants/api';
 import { useState } from 'react';
 
 interface InputData {
@@ -49,6 +49,7 @@ export const SignIn = () => {
     const { token, refreshToken } = data;
 
     setTokenAndRefreshToken(token, refreshToken);
+    sessionStorage.setItem(USER_STATUS_KEY, data.data.roleType);
     navigate('/');
   };
 

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -11,6 +11,8 @@ import { fetchSignIn } from '../api/auth';
 import type { AxiosError } from 'axios';
 import { ACCESS_TOKEN_KEY, USER_STATUS_KEY } from '../constants/api';
 import { useState } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { AuthStateAtom } from '../store/auth';
 
 interface InputData {
   email?: string;
@@ -36,6 +38,7 @@ export const SignIn = () => {
   const navigate = useNavigate();
 
   const [errorMsg, setErrorMsg] = useState('');
+  const setAuthState = useSetRecoilState(AuthStateAtom);
 
   const setTokenAndRefreshToken = (rowToken: string, rowRefresh: string) => {
     const token = rowToken.replace('Bearer', '');
@@ -45,11 +48,13 @@ export const SignIn = () => {
     document.cookie = `refreshToken=${refreshToken}; path=/; max-age=2592000; samesite=strict`;
   };
 
-  const signInSuccess = (data: SignInProps) => {
-    const { token, refreshToken } = data;
+  const signInSuccess = (res: SignInProps) => {
+    const { token, refreshToken, data } = res;
 
     setTokenAndRefreshToken(token, refreshToken);
-    sessionStorage.setItem(USER_STATUS_KEY, data.data.roleType);
+    sessionStorage.setItem(USER_STATUS_KEY, data.roleType);
+    setAuthState(true);
+
     navigate('/');
   };
 

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -9,10 +9,10 @@ import { Controller, useForm } from 'react-hook-form';
 import { useMutation } from '@tanstack/react-query';
 import { fetchSignIn } from '../api/auth';
 import type { AxiosError } from 'axios';
-import { ACCESS_TOKEN_KEY, USER_STATUS_KEY } from '../constants/api';
+import { ACCESS_TOKEN_KEY, USER_NICKNAME_KEY, USER_STATUS_KEY } from '../constants/api';
 import { useState } from 'react';
 import { useSetRecoilState } from 'recoil';
-import { AuthStateAtom } from '../store/auth';
+import { AuthStateAtom, NickNameAtom } from '../store/auth';
 
 interface InputData {
   email?: string;
@@ -39,6 +39,7 @@ export const SignIn = () => {
 
   const [errorMsg, setErrorMsg] = useState('');
   const setAuthState = useSetRecoilState(AuthStateAtom);
+  const setUserNickName = useSetRecoilState(NickNameAtom);
 
   const setTokenAndRefreshToken = (rowToken: string, rowRefresh: string) => {
     const token = rowToken.replace('Bearer', '');
@@ -50,11 +51,13 @@ export const SignIn = () => {
 
   const signInSuccess = (res: SignInProps) => {
     const { token, refreshToken, data } = res;
-
     setTokenAndRefreshToken(token, refreshToken);
-    sessionStorage.setItem(USER_STATUS_KEY, data.roleType);
-    setAuthState(true);
 
+    sessionStorage.setItem(USER_STATUS_KEY, data.roleType);
+    sessionStorage.setItem(USER_NICKNAME_KEY, data.nickname);
+
+    setAuthState(true);
+    setUserNickName(data.nickname);
     navigate('/');
   };
 

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -42,7 +42,7 @@ export const SignIn = () => {
     const refreshToken = rowRefresh.replace('Bearer', '');
 
     sessionStorage.setItem(ACCESS_TOKEN_KEY, token);
-    document.cookie = `refreshToken=${refreshToken}; path=/; max-age=31536000; samesite=strict`;
+    document.cookie = `refreshToken=${refreshToken}; path=/; max-age=2592000; samesite=strict`;
   };
 
   const signInSuccess = (data: SignInProps) => {

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -51,33 +51,25 @@ export const SignUp = () => {
     }
   };
 
-  const handleSignUpSuccess = () => {
-    setIsOpen(true);
-  };
-
-  const handleEmailAuthError = () => {
-    // eslint-disable-next-line no-alert
-    alert('인증에 실패했습니다! 로그인 후 다시 시도해 주세요.');
-    navigate('/');
-  };
-
-  // NOTICE: 아직 서버 인증이 안풀려서 올바르게 인증해도 401에러가 뜸
-  const handleEmailAuthSuccess = () => {
-    // eslint-disable-next-line no-alert
-    alert('인증에 성공했습니다! 로그인 해 주세요.');
-    navigate('/');
-  };
-
   const signUpMutation = useMutation({
     mutationFn: fetchSignUp,
-    onSuccess: handleSignUpSuccess,
+    onSuccess: () => setIsOpen(true),
     onError: handleError,
   });
 
   const emailAuthMutation = useMutation({
     mutationFn: emailAuth,
-    onError: handleEmailAuthError,
-    onSuccess: handleEmailAuthSuccess,
+    onError: () => {
+      // eslint-disable-next-line no-alert
+      alert('인증에 실패했습니다! 로그인 후 다시 시도해 주세요.');
+      navigate('/');
+    },
+    onSuccess: () => {
+      // NOTICE: 아직 서버 인증이 안풀려서 올바르게 인증해도 401에러가 뜸
+      // eslint-disable-next-line no-alert
+      alert('인증에 성공했습니다! 로그인 해 주세요.');
+      navigate('/');
+    },
   });
 
   const handleSingUp = async (data: InputData) => {

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-alert */
 import { Navigate, Outlet } from 'react-router-dom';
 import { ACCESS_TOKEN_KEY } from '../constants/api';
 
@@ -12,7 +13,10 @@ export const PrivateRoute = ({ authentication }: PrivateRouteProps) => {
 
   if (authentication) {
     return isAuthenticated === null || isAuthenticated === 'false' ? (
-      <Navigate to="/signin" />
+      <>
+        {alert('로그인이 필요합니다.')}
+        <Navigate to="/signin" />
+      </>
     ) : (
       <Outlet />
     );

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -19,7 +19,7 @@ export const PrivateRoute = ({ authentication, allowGuest }: PrivateRouteProps) 
       return <Navigate to="/signin" />;
     }
     if (userStatus === 'GUEST' && !allowGuest) {
-      alert('게스트 사용자는 냉장고를 만들 수 없습니다. 이메일 인증을 해주세요.');
+      alert('이메일 인증을 먼저 진행 해주세요.');
       return <Navigate to="/mypage" />;
     }
     return <Outlet />;

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,26 +1,29 @@
 /* eslint-disable no-alert */
 import { Navigate, Outlet } from 'react-router-dom';
-import { ACCESS_TOKEN_KEY } from '../constants/api';
+import { ACCESS_TOKEN_KEY, USER_STATUS_KEY } from '../constants/api';
 
 interface PrivateRouteProps {
   // eslint-disable-next-line react/no-unused-prop-types
   children?: React.ReactNode;
   authentication: boolean;
+  allowGuest?: boolean;
 }
 
-export const PrivateRoute = ({ authentication }: PrivateRouteProps) => {
+export const PrivateRoute = ({ authentication, allowGuest }: PrivateRouteProps) => {
   const isAuthenticated = sessionStorage.getItem(ACCESS_TOKEN_KEY);
+  const userStatus = sessionStorage.getItem(USER_STATUS_KEY);
 
   if (authentication) {
-    return isAuthenticated === null || isAuthenticated === 'false' ? (
-      <>
-        {alert('로그인이 필요합니다.')}
-        <Navigate to="/signin" />
-      </>
-    ) : (
-      <Outlet />
-    );
+    if (isAuthenticated === null) {
+      alert('로그인이 필요합니다.');
+      return <Navigate to="/signin" />;
+    }
+    if (userStatus === 'GUEST' && !allowGuest) {
+      alert('게스트 사용자는 냉장고를 만들 수 없습니다. 이메일 인증을 해주세요.');
+      return <Navigate to="/mypage" />;
+    }
+    return <Outlet />;
   }
 
-  return isAuthenticated === null || isAuthenticated === 'false' ? <Outlet /> : <Navigate to="/" />;
+  return isAuthenticated === null ? <Outlet /> : <Navigate to="/" />;
 };

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,0 +1,22 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { ACCESS_TOKEN_KEY } from '../constants/api';
+
+interface PrivateRouteProps {
+  // eslint-disable-next-line react/no-unused-prop-types
+  children?: React.ReactNode;
+  authentication: boolean;
+}
+
+export const PrivateRoute = ({ authentication }: PrivateRouteProps) => {
+  const isAuthenticated = sessionStorage.getItem(ACCESS_TOKEN_KEY);
+
+  if (authentication) {
+    return isAuthenticated === null || isAuthenticated === 'false' ? (
+      <Navigate to="/signin" />
+    ) : (
+      <Outlet />
+    );
+  }
+
+  return isAuthenticated === null || isAuthenticated === 'false' ? <Outlet /> : <Navigate to="/" />;
+};

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -16,6 +16,7 @@ export const Router = () => {
     <Routes>
       <Route index element={<Index />} />
       <Route path="/recipe/:recipeId" element={<RecipeView />} />
+      <Route path="/recipe" element={<Recipe />} />
       <Route element={<PrivateRoute authentication={false} />}>
         <Route path="/signup" element={<SignUp />} />
         <Route path="/signin" element={<SignIn />} />
@@ -25,7 +26,6 @@ export const Router = () => {
         <Route path="/refrigerator" element={<MyRefrigerator />} />
         <Route path="/mypage" element={<MyPage />} />
         <Route path="/scrap" element={<Scrap />} />
-        <Route path="/recipe" element={<Recipe />} />
         <Route path="/review-post" element={<ReviewPost />} />
       </Route>
     </Routes>

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -15,10 +15,10 @@ export const Router = () => {
   return (
     <Routes>
       <Route index element={<Index />} />
+      <Route path="/recipe/:recipeId" element={<RecipeView />} />
       <Route element={<PrivateRoute authentication={false} />}>
         <Route path="/signup" element={<SignUp />} />
         <Route path="/signin" element={<SignIn />} />
-        <Route path="/recipe/:recipeId" element={<RecipeView />} />
       </Route>
       <Route element={<PrivateRoute authentication />}>
         <Route path="/add" element={<AddRecipe />} />

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -22,13 +22,13 @@ export const Router = () => {
         <Route path="/signin" element={<SignIn />} />
       </Route>
       <Route element={<PrivateRoute authentication allowGuest />}>
-        <Route path="/add" element={<AddRecipe />} />
         <Route path="/mypage" element={<MyPage />} />
-        <Route path="/scrap" element={<Scrap />} />
-        <Route path="/review-post" element={<ReviewPost />} />
       </Route>
       <Route element={<PrivateRoute authentication />}>
+        <Route path="/scrap" element={<Scrap />} />
+        <Route path="/add" element={<AddRecipe />} />
         <Route path="/refrigerator" element={<MyRefrigerator />} />
+        <Route path="/review-post" element={<ReviewPost />} />
       </Route>
     </Routes>
   );

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -21,12 +21,14 @@ export const Router = () => {
         <Route path="/signup" element={<SignUp />} />
         <Route path="/signin" element={<SignIn />} />
       </Route>
-      <Route element={<PrivateRoute authentication />}>
+      <Route element={<PrivateRoute authentication allowGuest />}>
         <Route path="/add" element={<AddRecipe />} />
-        <Route path="/refrigerator" element={<MyRefrigerator />} />
         <Route path="/mypage" element={<MyPage />} />
         <Route path="/scrap" element={<Scrap />} />
         <Route path="/review-post" element={<ReviewPost />} />
+      </Route>
+      <Route element={<PrivateRoute authentication />}>
+        <Route path="/refrigerator" element={<MyRefrigerator />} />
       </Route>
     </Routes>
   );

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -9,20 +9,25 @@ import { MyRefrigerator } from '../pages/MyRefrigerator';
 import { ReviewPost } from '../pages/ReviewPost';
 import { RecipeView } from '../pages/RecipeView';
 import { Recipe } from '../pages/Recipe';
+import { PrivateRoute } from './PrivateRoute';
 
 export const Router = () => {
   return (
     <Routes>
       <Route index element={<Index />} />
-      <Route path="/add" element={<AddRecipe />} />
-      <Route path="/refrigerator" element={<MyRefrigerator />} />
-      <Route path="/signin" element={<SignIn />} />
-      <Route path="/signup" element={<SignUp />} />
-      <Route path="/mypage" element={<MyPage />} />
-      <Route path="/scrap" element={<Scrap />} />
-      <Route path="/recipe" element={<Recipe />} />
-      <Route path="/recipe/:recipeId" element={<RecipeView />} />
-      <Route path="/review-post" element={<ReviewPost />} />
+      <Route element={<PrivateRoute authentication={false} />}>
+        <Route path="/signup" element={<SignUp />} />
+        <Route path="/signin" element={<SignIn />} />
+        <Route path="/recipe/:recipeId" element={<RecipeView />} />
+      </Route>
+      <Route element={<PrivateRoute authentication />}>
+        <Route path="/add" element={<AddRecipe />} />
+        <Route path="/refrigerator" element={<MyRefrigerator />} />
+        <Route path="/mypage" element={<MyPage />} />
+        <Route path="/scrap" element={<Scrap />} />
+        <Route path="/recipe" element={<Recipe />} />
+        <Route path="/review-post" element={<ReviewPost />} />
+      </Route>
     </Routes>
   );
 };

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,7 +1,12 @@
 import { atom } from 'recoil';
-import { ACCESS_TOKEN_KEY } from '../constants/api';
+import { ACCESS_TOKEN_KEY, USER_NICKNAME_KEY } from '../constants/api';
 
 export const AuthStateAtom = atom({
   key: `AuthStateAtom`,
   default: !!sessionStorage.getItem(ACCESS_TOKEN_KEY),
+});
+
+export const NickNameAtom = atom({
+  key: 'NNickNameAtomick',
+  default: sessionStorage.getItem(USER_NICKNAME_KEY) ?? '',
 });

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,1 +1,7 @@
-// 아톰 정의
+import { atom } from 'recoil';
+import { ACCESS_TOKEN_KEY } from '../constants/api';
+
+export const AuthStateAtom = atom({
+  key: `AuthStateAtom`,
+  default: !!sessionStorage.getItem(ACCESS_TOKEN_KEY),
+});

--- a/src/utils/getRefreshToken.ts
+++ b/src/utils/getRefreshToken.ts
@@ -1,0 +1,9 @@
+export const getRefreshToken = (name: string) => {
+  const cookies = document.cookie.split('; ');
+  const refreshTokenCookie = cookies.find((cookie) => cookie.startsWith(`${name}=`));
+  if (refreshTokenCookie) {
+    const refreshToken = refreshTokenCookie.split('=')[1];
+    return refreshToken;
+  }
+  return null;
+};


### PR DESCRIPTION
## 작업내용

![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/107461545/570cbfc2-70c5-42eb-b61d-734e405ff379)

- 이메일 로그인 기능만 우선 구현된 상태입니다.
- 회원가입이 번거로우시다면 임시 로그인 계정으로 로그인 테스트 해보시면 편할 것 같습니다.
`
임시 로그인 계정 =>
 email: test@gmail.com
 password:  passwordld1
`
- PrivateRoute를 생성하여 로그인하지 않으면 사전 협의된 페이지를 제외하고는 볼 수 없도록 라우팅  처리를 하였습니다.
- 엑세스토큰은 세션스토리지에, 리프레쉬토큰은 쿠키에 저장하여 관리합니다.
- 로그아웃시 엑세스토큰과 리프레쉬토큰 모두 삭제됩니다.

## 작업 목적
- 이메일 로그인 기능 구현