### PR TITLE
냉장고를 부탁해 #73 토큰 저장방식 수정, axios 인터셉터 무한 요청 버그 수정

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -9,7 +9,6 @@ export const axiosAuth = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-  withCredentials: true,
 });
 
 // 인증이 필요하지 않은 페이지에서 데이터를 패칭할때 사용할 인스턴스

--- a/src/api/fridge.ts
+++ b/src/api/fridge.ts
@@ -1,14 +1,10 @@
 import { END_POINTS } from '../constants/api';
 import type { Ingredient, Suggest } from '../types/ingredientType';
-import { axiosDefault } from './axiosInstance';
+import { axiosAuth, axiosDefault } from './axiosInstance';
 
 export const getIngredient = async () => {
-  try {
-    const response = await axiosDefault.get<Ingredient[]>(END_POINTS.INGREDIENT);
-    return response.data;
-  } catch (error) {
-    throw new Error(`${error}`);
-  }
+  const response = await axiosAuth.get<Ingredient[]>(END_POINTS.FRIDGE);
+  return response.data;
 };
 
 export const getIngredientSuggest = async () => {

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -1,7 +1,14 @@
 import type { AxiosError, InternalAxiosRequestConfig } from 'axios';
-import { ACCESS_TOKEN_KEY, END_POINTS, ROOT_URL } from '../constants/api';
+import {
+  ACCESS_TOKEN_KEY,
+  END_POINTS,
+  ROOT_URL,
+  USER_NICKNAME_KEY,
+  USER_STATUS_KEY,
+} from '../constants/api';
 import { axiosAuth } from './axiosInstance';
 import { getRefreshToken } from '../utils/getRefreshToken';
+import axios from 'axios';
 
 let isRefreshing = false;
 
@@ -50,6 +57,16 @@ export const handleTokenError = async (error: AxiosError) => {
         return axiosAuth(originalRequest);
       }
     } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 403) {
+        sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+        sessionStorage.removeItem(USER_STATUS_KEY);
+        sessionStorage.removeItem(USER_NICKNAME_KEY);
+
+        document.cookie = `refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+        // eslint-disable-next-line no-alert
+        alert('토큰이 만료되었습니다. 다시 로그인해 주세요.');
+        window.location.href = `${ROOT_URL}signin`;
+      }
       throw new Error(`${error}`);
     }
   }

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -44,6 +44,13 @@ export const Header = () => {
     <Container>
       <Wrapper>
         <BasicInput id="text" type="email" placeholder="레시피를 검색해 주세요." />
+        {userNickName && (
+          <Nickname>
+            <StyledLink to="/mypage">
+              <span>{`${userNickName}님`}</span>
+            </StyledLink>
+          </Nickname>
+        )}
         {authState ? (
           <>
             <BasicButton
@@ -68,13 +75,6 @@ export const Header = () => {
             로그인
           </BasicButton>
         )}
-        {userNickName && (
-          <Nickname>
-            <StyledLink to="/mypage">
-              <span>{`${userNickName}님 환영합니다.`}</span>
-            </StyledLink>
-          </Nickname>
-        )}
       </Wrapper>
       {sideBar && <SideBar isOpen={sideBar} handleSidebar={() => setSideBar(false)} />}
     </Container>
@@ -93,9 +93,8 @@ const Container = styled.header`
 `;
 
 const Wrapper = styled.div`
-  position: relative;
   display: grid;
-  grid-template-columns: 1fr auto auto;
+  grid-template-columns: 1fr auto auto auto;
   align-items: center;
   gap: 12px;
   width: 768px;
@@ -130,7 +129,6 @@ export const StyledLink = styled(Link)`
 `;
 
 const Nickname = styled.p`
-  position: absolute;
   font-size: 14px;
 
   bottom: -27px;

--- a/src/components/pages/fridge/MyIngredientList.tsx
+++ b/src/components/pages/fridge/MyIngredientList.tsx
@@ -12,7 +12,11 @@ interface UpdatedItem {
 }
 
 export const MyIngredientList = () => {
-  const { data } = useQuery({ queryKey: [QUERY_KEY.ADD_INGREDIENT], queryFn: getIngredient });
+  const { data } = useQuery({
+    queryKey: [QUERY_KEY.ADD_INGREDIENT],
+    queryFn: getIngredient,
+  });
+
   const [edit, setEdit] = useState<boolean>(false);
   const [deletedItems, setDeletedItems] = useState<number[]>([]);
   const [updatedItems, setUpdatedItems] = useState<UpdatedItem>({});

--- a/src/hooks/api/queryClient.ts
+++ b/src/hooks/api/queryClient.ts
@@ -6,7 +6,7 @@ export const queryClient = new QueryClient({
     queries: {
       refetchOnWindowFocus: false, // 개발중 서버 부하를 줄이기 위해 임시로 false로 설정
       staleTime: 1000 * 60 * 5,
-      retry: 2,
+      retry: 1,
     },
   },
 });

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -41,17 +41,11 @@ export const SignIn = () => {
   const setAuthState = useSetRecoilState(AuthStateAtom);
   const setUserNickName = useSetRecoilState(NickNameAtom);
 
-  const setTokenAndRefreshToken = (rowToken: string, rowRefresh: string) => {
-    const token = rowToken.replace('Bearer', '');
-    const refreshToken = rowRefresh.replace('Bearer', '');
+  const signInSuccess = (res: SignInProps) => {
+    const { token, refreshToken, data } = res;
 
     sessionStorage.setItem(ACCESS_TOKEN_KEY, token);
     document.cookie = `refreshToken=${refreshToken}; path=/; max-age=2592000; samesite=strict`;
-  };
-
-  const signInSuccess = (res: SignInProps) => {
-    const { token, refreshToken, data } = res;
-    setTokenAndRefreshToken(token, refreshToken);
 
     sessionStorage.setItem(USER_STATUS_KEY, data.roleType);
     sessionStorage.setItem(USER_NICKNAME_KEY, data.nickname);

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-alert */
 import { Navigate, Outlet } from 'react-router-dom';
 import { ACCESS_TOKEN_KEY, USER_STATUS_KEY } from '../constants/api';
+import { useRecoilValue } from 'recoil';
+import { AuthStateAtom } from '../store/auth';
 
 interface PrivateRouteProps {
   // eslint-disable-next-line react/no-unused-prop-types
@@ -12,9 +14,15 @@ interface PrivateRouteProps {
 export const PrivateRoute = ({ authentication, allowGuest }: PrivateRouteProps) => {
   const isAuthenticated = sessionStorage.getItem(ACCESS_TOKEN_KEY);
   const userStatus = sessionStorage.getItem(USER_STATUS_KEY);
+  const AuthState = useRecoilValue(AuthStateAtom);
 
   if (authentication) {
     if (isAuthenticated === null) {
+      if (AuthState) {
+        alert('토큰이 만료되어 다시 로그인 해야 합니다.');
+        return <Navigate to="/signin" />;
+      }
+
       alert('로그인이 필요합니다.');
       return <Navigate to="/signin" />;
     }


### PR DESCRIPTION
## 작업내용
401 에러를 받으면 다시 무한 요청을 보내는 버그를 수정하였습니다.

원인은 인터셉터 파일에 있는  handleTokenError 함수에서 401에러를 받으면  axiosAuth 인스턴스를 통해 리프레쉬 토큰을 요청하는데, 만약 리프레쉬토큰 요청의 응답값으로도 401 에러를 받게 된다면,  axiosAuth는 응답결과 중 에러를 잡아서 handleTokenError 함수를 호출하도록 되어있기에 다시 handleTokenError 함수가 호출되어 무한으로 요청이 갔었습니다.

이 부분을 isRefreshing 이라는 변수를 통해 한번만 요청을 하도록 막았습니다.

또한 리프레쉬 토큰또한 만료가 되었을시 세션스토리지와 쿠키의 값을 모두 삭제하고 유저에게 다시 로그인 하도록 유도하였습니다. 리프레쉬 토큰이 만료된 상황에서 사용자가 라우팅시 `토큰이 만료되어 다시 로그인 해야 합니다.` 라는 메시지를 띄우도록 PrivateRoute를 수정하였습니다.

마지막으로 토큰을 저장할때 Bearer를 지우고 저장하고 서버에 보낼때는 다시 Bearer를 붙혀서 보냈는데 그러면 토큰이 제대로 전달되지 않는 문제가 있어서 토큰과 리프레쉬토큰 저장 방식을 수정하였습니다.

## 작업목적
axiosAuth 인스턴스 무한 요청 버그 수정