### PR TITLE
냉장고를 부탁해 #83 재료 등록 페이지 데이터 전송 방식을 수정 및 재료의 양 추가

### DIFF
--- a/src/api/recipe.ts
+++ b/src/api/recipe.ts
@@ -1,5 +1,18 @@
 import { END_POINTS } from '../constants/api';
+import type { Ingredient, StepImage } from '../pages/AddRecipe';
 import { axiosDefault, axiosFormData } from './axiosInstance';
+
+interface AddRecipeData {
+  title: string;
+  summary: string;
+  recipeImage: File;
+  steps: {
+    description: string;
+    tip: string;
+  }[];
+  ingredient: Ingredient[] | undefined;
+  stepImage: StepImage[];
+}
 
 export const getNewRecipe = async () => {
   const response = await axiosDefault.get(END_POINTS.RECIPES, {
@@ -13,7 +26,30 @@ export const getDetailRecipe = async (recipeId: string) => {
   return result.data;
 };
 
-export const addNewRecipe = async (formData: FormData) => {
+export const addNewRecipe = async (recipeData: AddRecipeData) => {
+  const formData = new FormData();
+
+  formData.append('title', recipeData.title);
+  formData.append('summary', recipeData.summary);
+  formData.append(`recipeImage`, recipeData.recipeImage);
+
+  formData.append(
+    'steps',
+    new Blob([JSON.stringify(recipeData.steps)], { type: 'application/json' })
+  );
+
+  formData.append(
+    'ingredients',
+    new Blob([JSON.stringify(recipeData.ingredient)], { type: 'application/json' })
+  );
+
+  recipeData.stepImage.forEach((item, index) => {
+    if (item.image) {
+      formData.append(`stepImages[${index}]`, item.image);
+    }
+  });
+
   const { data } = await axiosFormData.post(END_POINTS.RECIPES, formData);
+
   return data;
 };

--- a/src/components/pages/Recipe/RecipeStep.tsx
+++ b/src/components/pages/Recipe/RecipeStep.tsx
@@ -4,29 +4,25 @@ import { theme } from '../../../styles/theme';
 import { type ChangeEvent } from 'react';
 import { FaPlus } from 'react-icons/fa6';
 import { FaTrash } from 'react-icons/fa';
+import type { Control } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 
 interface stepProps {
   image: File | null;
-  content: string;
   index: number;
-  tip: string;
-  deleteStep: (index: number) => void;
-  handleImageStep: (event: ChangeEvent<HTMLInputElement>, index: number) => void;
-  handleContentStep: (event: ChangeEvent<HTMLTextAreaElement>, index: number) => void;
+  control: Control;
+  handleDeleteStep: (index: number) => void;
   deleteImageStep: (index: number) => void;
-  handleTipStep: (event: ChangeEvent<HTMLInputElement>, index: number) => void;
+  handleImageStep: (event: ChangeEvent<HTMLInputElement>, index: number) => void;
 }
 
 export const RecipeStep = ({
   image,
-  content,
   index,
-  tip,
-  deleteStep,
-  handleImageStep,
-  handleContentStep,
+  control,
   deleteImageStep,
-  handleTipStep,
+  handleDeleteStep,
+  handleImageStep,
 }: stepProps) => {
   return (
     <>
@@ -41,7 +37,7 @@ export const RecipeStep = ({
             이미지 삭제
           </BasicButton>
         )}
-        {index >= 1 && <StyledTrash onClick={() => deleteStep(index)} />}
+        {index >= 1 && <StyledTrash onClick={() => handleDeleteStep(index)} />}
       </TopWrapper>
 
       <RecipeContainer>
@@ -60,6 +56,7 @@ export const RecipeStep = ({
                 <p>이미지 추가</p>
                 <PlusIcon />
               </Placeholder>
+
               <FileInput
                 type="file"
                 id={`${index}file`}
@@ -68,18 +65,32 @@ export const RecipeStep = ({
               />
             </>
           )}
-          <input
-            type="text"
-            value={tip}
-            placeholder="당신만의 팁은?"
-            onChange={(event) => handleTipStep(event, index)}
-          ></input>
+          <Controller
+            name={`${index}.tip`}
+            control={control}
+            defaultValue=""
+            render={({ field }) => (
+              <input
+                id={`${index}.tip`}
+                type="text"
+                placeholder="당신만의 팁은?"
+                {...field}
+              ></input>
+            )}
+          />
         </div>
-        <Content
-          value={content}
-          onChange={(event) => handleContentStep(event, index)}
-          placeholder="레시피의 내용을 입력해 주세요."
-        ></Content>
+        <Controller
+          name={`${index}.content`}
+          control={control}
+          defaultValue=""
+          render={({ field }) => (
+            <Content
+              id={`${index}.content`}
+              placeholder="레시피의 내용을 입력해 주세요."
+              {...field}
+            ></Content>
+          )}
+        />
       </RecipeContainer>
     </>
   );

--- a/src/components/pages/Recipe/UsedIngrident.tsx
+++ b/src/components/pages/Recipe/UsedIngrident.tsx
@@ -37,7 +37,7 @@ const AddIngrident = styled.div`
   grid-template-columns: 1fr 1fr 1fr 1fr;
   place-items: center;
   gap: 10px;
-  margin: 10px;
+  margin-top: 15px;
 `;
 
 const Ingridient = styled.div`
@@ -49,6 +49,7 @@ const Ingridient = styled.div`
   padding: 10px;
   border-radius: 10px;
   width: 100%;
+  background-color: ${(props) => props.theme.colors.grayishWhite};
 
   div > svg {
     position: absolute;
@@ -66,9 +67,9 @@ const Ingridient = styled.div`
     outline: none;
     width: 70px;
     height: 30px;
-    padding-left: 10px;
     margin-top: 10px;
     outline: none;
     border: 1px solid ${(props) => props.theme.colors.gray};
+    text-align: center;
   }
 `;

--- a/src/components/pages/Recipe/UsedIngrident.tsx
+++ b/src/components/pages/Recipe/UsedIngrident.tsx
@@ -1,0 +1,74 @@
+import { styled } from 'styled-components';
+import { MdClose } from 'react-icons/md';
+
+interface Ingredient {
+  name: string;
+  amount: string;
+}
+
+interface AddedIngredient {
+  addItemList: Ingredient[] | undefined;
+  setAddItemList: (name: string, amount: string) => void;
+  deletItem: (name: string) => void;
+}
+
+export const UsedIngrident = ({ addItemList, setAddItemList, deletItem }: AddedIngredient) => {
+  return (
+    <AddIngrident>
+      {addItemList?.map((e, i) => (
+        <Ingridient key={i}>
+          <div>
+            <span>{e.name}</span>
+            <MdClose onClick={() => deletItem(e.name)} />
+          </div>
+          <input
+            type="text"
+            placeholder="재료 양"
+            onChange={(event) => setAddItemList(e.name, event.target.value)}
+          ></input>
+        </Ingridient>
+      ))}
+    </AddIngrident>
+  );
+};
+
+const AddIngrident = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  place-items: center;
+  gap: 10px;
+  margin: 10px;
+`;
+
+const Ingridient = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border: 1px solid ${(props) => props.theme.colors.darkGray};
+  padding: 10px;
+  border-radius: 10px;
+  width: 100%;
+
+  div > svg {
+    position: absolute;
+    top: 3px;
+    right: 5px;
+    cursor: pointer;
+  }
+
+  div > span {
+    font-weight: 600;
+  }
+
+  input {
+    border-radius: 5px;
+    outline: none;
+    width: 70px;
+    height: 30px;
+    padding-left: 10px;
+    margin-top: 10px;
+    outline: none;
+    border: 1px solid ${(props) => props.theme.colors.gray};
+  }
+`;

--- a/src/components/pages/Recipe/UsedIngrident.tsx
+++ b/src/components/pages/Recipe/UsedIngrident.tsx
@@ -9,17 +9,17 @@ interface Ingredient {
 interface AddedIngredient {
   addItemList: Ingredient[] | undefined;
   setAddItemList: (name: string, amount: string) => void;
-  deletItem: (name: string) => void;
+  deleteItem: (name: string) => void;
 }
 
-export const UsedIngrident = ({ addItemList, setAddItemList, deletItem }: AddedIngredient) => {
+export const UsedIngrident = ({ addItemList, setAddItemList, deleteItem }: AddedIngredient) => {
   return (
     <AddIngrident>
       {addItemList?.map((e, i) => (
         <Ingridient key={i}>
           <div>
             <span>{e.name}</span>
-            <MdClose onClick={() => deletItem(e.name)} />
+            <MdClose onClick={() => deleteItem(e.name)} />
           </div>
           <input
             type="text"

--- a/src/pages/AddRecipe.tsx
+++ b/src/pages/AddRecipe.tsx
@@ -105,6 +105,12 @@ export const AddRecipe = () => {
       return;
     }
 
+    if (ingredient?.length === 0) {
+      // eslint-disable-next-line no-alert
+      alert('재료를 한개 이상 추가해 주세요.');
+      return;
+    }
+
     const steps = stepImage.map((_, index) => {
       const { content } = data[index];
       const { tip } = data[index];

--- a/src/pages/AddRecipe.tsx
+++ b/src/pages/AddRecipe.tsx
@@ -13,7 +13,7 @@ import { Controller, useForm } from 'react-hook-form';
 import { RecipeStep } from '../components/pages/Recipe/RecipeStep';
 import { UsedIngrident } from '../components/pages/Recipe/UsedIngrident';
 
-interface StepImage {
+export interface StepImage {
   image: File | null;
 }
 
@@ -26,7 +26,7 @@ interface InputData {
   };
 }
 
-interface Ingredient {
+export interface Ingredient {
   name: string;
   amount: string;
 }
@@ -140,7 +140,16 @@ export const AddRecipe = () => {
       }
     });
 
-    addRecipeMutation.mutate(formData);
+    const finalData = {
+      title: data.title.title,
+      summary: data.summary.summary,
+      recipeImage: thumbnail,
+      steps,
+      ingredient,
+      stepImage,
+    };
+
+    addRecipeMutation.mutate(finalData);
   };
 
   const handleDeleteStep = (index: number) => {
@@ -159,7 +168,7 @@ export const AddRecipe = () => {
       <UsedIngrident
         addItemList={ingredient}
         setAddItemList={setIngridentAmount}
-        deletItem={deleteIngredientByName}
+        deleteItem={deleteIngredientByName}
       />
       <WriteContainer onSubmit={handleSubmit(onSubmit)}>
         <Controller


### PR DESCRIPTION
## 작업내용
![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/107461545/9d22d664-8c2c-4775-828d-14d47a180622)
- 백엔드와 협의하여 데이터 전송 방식을 바꾸었습니다.
- 재료를 추가할시 양을 입력할 수 있는 칸을 추가하였습니다.

## 작업목적
- 백엔드와의 데이터 전송 방식을 협의하여 맞춤