### PR TITLE
냉장고를 부탁해 #90 로그인 후 이메일 인증 기능 구현

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -45,3 +45,8 @@ export const fetchSocialSignIn = async (provider: string) => {
   const { data } = await axiosDefault.get(`${END_POINTS.OAUTH}${provider}`);
   return data;
 };
+
+export const fetchLogOut = async () => {
+  const { data } = await axiosAuth.get(END_POINTS.LOGOUT);
+  return data;
+};

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -14,6 +14,7 @@ interface SignInProps {
 
 interface AuthCode {
   code: string;
+  email?: string;
 }
 
 export const fetchSignUp = async (params: SignUpProps) => {
@@ -31,6 +32,11 @@ export const fetchSignIn = async (params: SignInProps) => {
 };
 
 export const emailAuth = async (code: AuthCode) => {
+  const { data } = await axiosDefault.post(END_POINTS.CONFIRM, code);
+  return data;
+};
+
+export const emailAuthInMyPage = async (code: AuthCode) => {
   const { data } = await axiosAuth.post(END_POINTS.CONFIRM, code);
   return data;
 };

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,5 +1,5 @@
 import { END_POINTS } from '../constants/api';
-import { axiosDefault } from './axiosInstance';
+import { axiosAuth, axiosDefault } from './axiosInstance';
 
 interface SignUpProps {
   email: string;
@@ -10,6 +10,10 @@ interface SignUpProps {
 interface SignInProps {
   email: string;
   password: string;
+}
+
+interface AuthCode {
+  code: string;
 }
 
 export const fetchSignUp = async (params: SignUpProps) => {
@@ -26,8 +30,8 @@ export const fetchSignIn = async (params: SignInProps) => {
   return { data, token, refreshToken };
 };
 
-export const emailAuth = async (code: string) => {
-  const { data } = await axiosDefault.post(END_POINTS.CONFIRM, code);
+export const emailAuth = async (code: AuthCode) => {
+  const { data } = await axiosAuth.post(END_POINTS.CONFIRM, code);
   return data;
 };
 

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -80,7 +80,8 @@ export const handleTokenError = async (error: AxiosError) => {
     }
   }
 
-  if (isRefreshing && error.response.status === 403) {
+  if ((isRefreshing && error.response.status === 403) || error.response.status === 401) {
+    // eslint-disable-next-line no-alert
     alert('인증에 문제가 발생했습니다.');
   }
 

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -44,7 +44,7 @@ export const handleTokenError = async (error: AxiosError) => {
         {},
         {
           headers: {
-            Authorization: `Bearer ${refreshToken}d`,
+            Authorization: `Bearer ${refreshToken}`,
           },
         }
       );

--- a/src/api/recipe.ts
+++ b/src/api/recipe.ts
@@ -29,23 +29,24 @@ export const getDetailRecipe = async (recipeId: string) => {
 export const addNewRecipe = async (recipeData: AddRecipeData) => {
   const formData = new FormData();
 
-  formData.append('title', recipeData.title);
-  formData.append('summary', recipeData.summary);
-  formData.append(`recipeImage`, recipeData.recipeImage);
+  const requestData = {
+    title: recipeData.title,
+    summary: recipeData.summary,
+    ingredients: recipeData.ingredient,
+    steps: recipeData.steps,
+  };
 
-  formData.append(
-    'steps',
-    new Blob([JSON.stringify(recipeData.steps)], { type: 'application/json' })
-  );
+  console.log(requestData);
 
-  formData.append(
-    'ingredients',
-    new Blob([JSON.stringify(recipeData.ingredient)], { type: 'application/json' })
-  );
+  const requestBlob = new Blob([JSON.stringify(requestData)], { type: 'application/json' });
+
+  formData.append('request', requestBlob);
 
   recipeData.stepImage.forEach((item) => {
     formData.append(`stepImages`, item.image || new Blob());
   });
+
+  formData.append('recipeImage', recipeData.recipeImage);
 
   const { data } = await axiosFormData.post(END_POINTS.RECIPES, formData);
 

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -17,13 +17,13 @@ import { fetchLogOut } from '../../api/auth';
 
 export const Header = () => {
   const [sideBar, setSideBar] = useState(false);
-  const [isLogOut, setIsLogOut] = useState(false);
 
   const navigation = useNavigate();
 
   const setCurrentCategory = useSetRecoilState(currentCategoryAtom);
   const [userNickName, setUserNickName] = useRecoilState(NickNameAtom);
   const [authState, setAuthState] = useRecoilState(AuthStateAtom);
+  const [isLogOut, setIsLogOut] = useState(false);
 
   const { data } = useQuery({
     queryKey: [QUERY_KEY.LOGOUT],
@@ -39,17 +39,20 @@ export const Header = () => {
 
   const handleLogOut = () => {
     setIsLogOut(true);
+    navigation('/');
+
     setAuthState(false);
     setUserNickName('');
-
     // eslint-disable-next-line no-alert
     alert('로그아웃 되었습니다.');
   };
 
-  if (data) {
+  if (data && isLogOut) {
+    setIsLogOut(false);
     sessionStorage.removeItem(ACCESS_TOKEN_KEY);
     sessionStorage.removeItem(USER_STATUS_KEY);
     sessionStorage.removeItem(USER_NICKNAME_KEY);
+
     document.cookie = `refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
   }
 

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -11,9 +11,13 @@ import { TbBellFilled } from 'react-icons/tb';
 import { ACCESS_TOKEN_KEY, USER_NICKNAME_KEY, USER_STATUS_KEY } from '../../constants/api';
 import { AuthStateAtom, NickNameAtom } from '../../store/auth';
 import { device } from '../../styles/media';
+import { useQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '../../constants/queryKey';
+import { fetchLogOut } from '../../api/auth';
 
 export const Header = () => {
   const [sideBar, setSideBar] = useState(false);
+  const [isLogOut, setIsLogOut] = useState(false);
 
   const navigation = useNavigate();
 
@@ -21,24 +25,33 @@ export const Header = () => {
   const [userNickName, setUserNickName] = useRecoilState(NickNameAtom);
   const [authState, setAuthState] = useRecoilState(AuthStateAtom);
 
+  const { data } = useQuery({
+    queryKey: [QUERY_KEY.LOGOUT],
+    queryFn: fetchLogOut,
+    enabled: isLogOut,
+    staleTime: 0,
+  });
+
   const handleLogin = () => {
     navigation('/signin');
     setCurrentCategory('');
   };
 
   const handleLogOut = () => {
-    navigation('/');
-
-    sessionStorage.removeItem(ACCESS_TOKEN_KEY);
-    sessionStorage.removeItem(USER_STATUS_KEY);
-    sessionStorage.removeItem(USER_NICKNAME_KEY);
-
-    document.cookie = `refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+    setIsLogOut(true);
     setAuthState(false);
     setUserNickName('');
+
     // eslint-disable-next-line no-alert
     alert('로그아웃 되었습니다.');
   };
+
+  if (data) {
+    sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+    sessionStorage.removeItem(USER_STATUS_KEY);
+    sessionStorage.removeItem(USER_NICKNAME_KEY);
+    document.cookie = `refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+  }
 
   return (
     <Container>

--- a/src/components/pages/myPage/EmailAuth.tsx
+++ b/src/components/pages/myPage/EmailAuth.tsx
@@ -1,14 +1,28 @@
+/* eslint-disable no-console */
+/* eslint-disable no-alert */
 import styled from 'styled-components';
 import { BasicInput } from '../../common/BasicInput';
 import { BasicButton } from '../../common/BasicButton';
 import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import { emailAuth } from '../../../api/auth';
+import { emailAuthInMyPage } from '../../../api/auth';
+import { axiosAuth } from '../../../api/axiosInstance';
+import { END_POINTS, USER_STATUS_KEY } from '../../../constants/api';
+import type { AxiosError } from 'axios';
 
 export const EmailAuth = () => {
   const [authCode, setAuthCode] = useState<string | undefined>('');
 
-  const { mutate } = useMutation({ mutationFn: emailAuth });
+  const { mutate } = useMutation({
+    mutationFn: emailAuthInMyPage,
+    onSuccess: (data) => {
+      alert('이메일 인증이 완료 되었습니다.');
+      sessionStorage.setItem(USER_STATUS_KEY, data.data.role);
+    },
+    onError: (error: AxiosError) => {
+      console.error(error);
+    },
+  });
 
   const handleSendAuthCode = () => {
     if (!authCode) {
@@ -21,6 +35,11 @@ export const EmailAuth = () => {
     };
     mutate(finalData);
     setAuthCode('');
+  };
+
+  const leave = async () => {
+    const { data } = await axiosAuth.delete(END_POINTS.LEAVE);
+    console.log(data);
   };
 
   return (
@@ -36,6 +55,9 @@ export const EmailAuth = () => {
       <BasicButton onClick={handleSendAuthCode} $bgcolor="#ff8527" type="text" $fontcolor="#fff">
         인증 확인
       </BasicButton>
+      <button type="button" onClick={leave}>
+        탈퇴
+      </button>
     </NicknameEditContainer>
   );
 };

--- a/src/components/pages/myPage/EmailAuth.tsx
+++ b/src/components/pages/myPage/EmailAuth.tsx
@@ -7,17 +7,26 @@ import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { emailAuthInMyPage } from '../../../api/auth';
 import { axiosAuth } from '../../../api/axiosInstance';
-import { END_POINTS, USER_STATUS_KEY } from '../../../constants/api';
+import {
+  ACCESS_TOKEN_KEY,
+  END_POINTS,
+  USER_NICKNAME_KEY,
+  USER_STATUS_KEY,
+} from '../../../constants/api';
 import type { AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 export const EmailAuth = () => {
   const [authCode, setAuthCode] = useState<string | undefined>('');
+  const navigation = useNavigate();
 
   const { mutate } = useMutation({
     mutationFn: emailAuthInMyPage,
     onSuccess: (data) => {
       alert('이메일 인증이 완료 되었습니다.');
+      console.log(data.data.token);
       sessionStorage.setItem(USER_STATUS_KEY, data.data.role);
+      sessionStorage.setItem(ACCESS_TOKEN_KEY, data.data.token);
     },
     onError: (error: AxiosError) => {
       console.error(error);
@@ -40,6 +49,13 @@ export const EmailAuth = () => {
   const leave = async () => {
     const { data } = await axiosAuth.delete(END_POINTS.LEAVE);
     console.log(data);
+
+    sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+    sessionStorage.removeItem(USER_STATUS_KEY);
+    sessionStorage.removeItem(USER_NICKNAME_KEY);
+
+    document.cookie = `refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+    navigation('/');
   };
 
   return (

--- a/src/components/pages/myPage/EmailAuth.tsx
+++ b/src/components/pages/myPage/EmailAuth.tsx
@@ -1,14 +1,40 @@
 import styled from 'styled-components';
 import { BasicInput } from '../../common/BasicInput';
 import { BasicButton } from '../../common/BasicButton';
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { emailAuth } from '../../../api/auth';
 
 export const EmailAuth = () => {
+  const [authCode, setAuthCode] = useState<string | undefined>('');
+
+  const { mutate } = useMutation({ mutationFn: emailAuth });
+
+  const handleSendAuthCode = () => {
+    if (!authCode) {
+      // eslint-disable-next-line no-alert
+      alert('인증번호를 입력해 주세요!');
+      return;
+    }
+    const finalData = {
+      code: authCode,
+    };
+    mutate(finalData);
+    setAuthCode('');
+  };
+
   return (
     <NicknameEditContainer>
-      <BasicInput id="nickname" type="text" placeholder="이메일을 입력하세요" />
+      <BasicInput
+        value={authCode}
+        onChange={(e) => setAuthCode(e?.target.value)}
+        id="nickname"
+        type="text"
+        placeholder="이메일로 도착한 인증 코드를 입력해 주세요."
+      />
       <br />
-      <BasicButton $bgcolor="#ff8527" type="text" $fontcolor="#fff">
-        인증번호 발송
+      <BasicButton onClick={handleSendAuthCode} $bgcolor="#ff8527" type="text" $fontcolor="#fff">
+        인증 확인
       </BasicButton>
     </NicknameEditContainer>
   );

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -20,6 +20,7 @@ export const END_POINTS = {
   OAUTH: 'auth/oauth?provider=',
   REISSUE: 'auth/token/reissue',
   LEAVE: 'auth/leave',
+  LOGOUT: 'auth/logout',
   MEMBER_INFO: 'members/info',
   NICKNAME: 'members/info/nickname',
   PASSWORD: 'members/info/password',

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -6,4 +6,5 @@ export const QUERY_KEY = {
   SOCIAL_SIGNIN: `socialSignIn`,
   GET_REVIEW: 'getReview',
   GET_INGREDIENT: 'getIngredient',
+  LOGOUT: 'logOut',
 } as const;

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -39,6 +39,7 @@ export const SignUp = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [errorMsg, setErrorMsg] = useState<ErrorMsg>();
   const [authCode, setAuthCode] = useState<string | undefined>('');
+  const [email, setEmail] = useState('');
 
   const handleError = (error: AxiosError) => {
     const errorData = error.response?.data as SignUpError;
@@ -80,6 +81,7 @@ export const SignUp = () => {
       password: data.pw as string,
       nickname: data.nickname as string,
     };
+    setEmail(data.email as string);
 
     signUpMutation.mutate(params);
     // setIsOpen(true);
@@ -94,8 +96,11 @@ export const SignUp = () => {
     }
 
     const finalData = {
+      email,
       code: authCode,
     };
+
+    console.log(finalData);
 
     emailAuthMutation.mutate(finalData);
   };
@@ -115,6 +120,8 @@ export const SignUp = () => {
   const onSubmit = handleSingUp;
 
   const password = watch('pw');
+
+  console.log(email);
 
   return (
     <SignUpContainer>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -59,13 +59,13 @@ export const SignUp = () => {
 
   const emailAuthMutation = useMutation({
     mutationFn: emailAuth,
-    onError: () => {
+    onError: (error) => {
+      // eslint-disable-next-line no-console
+      console.log(error);
       // eslint-disable-next-line no-alert
       alert('인증에 실패했습니다! 로그인 후 다시 시도해 주세요.');
-      navigate('/');
     },
     onSuccess: () => {
-      // NOTICE: 아직 서버 인증이 안풀려서 올바르게 인증해도 401에러가 뜸
       // eslint-disable-next-line no-alert
       alert('인증에 성공했습니다! 로그인 해 주세요.');
       navigate('/');
@@ -92,7 +92,12 @@ export const SignUp = () => {
       navigate('/');
       return;
     }
-    emailAuthMutation.mutate(authCode);
+
+    const finalData = {
+      code: authCode,
+    };
+
+    emailAuthMutation.mutate(finalData);
   };
 
   const handleAuthCancel = () => {


### PR DESCRIPTION
## 작업내용
![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/107461545/f41ed960-3517-48c4-8155-22d9c82ed610)
- 회원가입 후 모달로 이메일 인증 작업을 완료했습니다.
- 모달에서 하지 않더라도 마이페이지에서도 이메일 인증이 가능하게 작업하였습니다.
- 마이페이지 회원 탈퇴 버튼은 인증 테스트를 위해 임시로 만들어 놓은 버튼 입니다. 이후 탈퇴 작업때 마무리 지어 놓겠습니다. 당장은 완벽하게 작동되지 않습니다.
## 작업목적
- 회원가입 후 이메일 인증 기능 완성