### PR TITLE
냉장고를부탁해 #103 메인페이지 데이터 연동

### DIFF
--- a/src/api/recipe.ts
+++ b/src/api/recipe.ts
@@ -62,3 +62,13 @@ export const updateRecipe = async (recipeId: string, recipeData: AddRecipeData) 
   const { data } = await axiosFormData.post(`${END_POINTS.RECIPES}/${recipeId}`, recipeData);
   return data;
 };
+
+export const getLatestRecipes = async (size: number, page = 0) => {
+  const result = await axiosDefault.get(`${END_POINTS.RECIPES}/recent?page=${page}&size=${size}`);
+  return result.data;
+};
+
+export const getPopularRecipes = async (size: number, page = 0) => {
+  const result = await axiosDefault.get(`${END_POINTS.RECIPES}/popular?page=${page}&size=${size}`);
+  return result.data;
+};

--- a/src/components/common/CardList.tsx
+++ b/src/components/common/CardList.tsx
@@ -1,61 +1,29 @@
 import { styled } from 'styled-components';
 import { RecipeCard } from './RecipeCard';
 import type { Recipe } from '../../types/recipeType';
+import { useQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '../../constants/queryKey';
+import { getLatestRecipes } from '../../api/recipe';
 
 export const CardList = () => {
-  const data = [
-    {
-      id: 1,
-      title: '떡볶이',
-      summary: '요약',
-      recipeImageUrl:
-        'https://blog.kakaocdn.net/dn/bBeQzv/btq4dw1SNcQ/7b9ROACX8r0oWRUckQKib0/img.png',
-      reviewCount: 3,
-      createdAt: '2020-09-21',
-      member: {
-        id: 1,
-        nickName: '나에요',
-      },
-    },
-    {
-      id: 1,
-      title: '피자',
-      summary: '요약',
-      recipeImageUrl: 'https://img.hankyung.com/photo/202108/99.26501439.1-1200x.jpg',
-      reviewCount: 3,
-      createdAt: '2020-09-21',
-      member: {
-        id: 1,
-        nickName: '나에요',
-      },
-    },
-    {
-      id: 1,
-      title: '마라탕',
-      summary: '요약',
-      recipeImageUrl:
-        'https://d12zq4w4guyljn.cloudfront.net/750_750_20220702061143834_photo_4fceeae73135.jpg',
-      reviewCount: 3,
-      createdAt: '2020-09-21',
-      member: {
-        id: 1,
-        nickName: '나에요',
-      },
-    },
-  ];
+  const { data: latestRecipeData } = useQuery({
+    queryKey: [QUERY_KEY.GET_LATEST_RECIPE],
+    queryFn: () => getLatestRecipes(6),
+    select: (data) => data.data.content,
+  });
 
   return (
     <Card>
-      {data?.map((info: Recipe) => (
+      {latestRecipeData?.map((info: Recipe) => (
         <RecipeCard
           key={info.id}
           recipeTitle={info.title}
           briefExplanation={info.summary}
-          imageURL={info.recipeImageUrl}
-          date="2020-04-14"
-          reviewCount={10}
-          auther="나에요"
-          viewCount={117}
+          imageURL={info.imageUrl}
+          date={info.createdAt}
+          reviewCount={info.reviewCount}
+          auther={info.author.nickname}
+          viewCount={info.viewCount}
           size="small"
         />
       ))}

--- a/src/components/common/CardList.tsx
+++ b/src/components/common/CardList.tsx
@@ -16,6 +16,7 @@ export const CardList = () => {
     <Card>
       {latestRecipeData?.map((info: Recipe) => (
         <RecipeCard
+          recipeId={info.id}
           key={info.id}
           recipeTitle={info.title}
           briefExplanation={info.summary}

--- a/src/components/common/Carousel.tsx
+++ b/src/components/common/Carousel.tsx
@@ -15,9 +15,15 @@ interface CarouselProps {
   carouselDataInfo: Recipe[];
   dotsState: boolean;
   viewCount: number;
+  handleClick?: (recipeId: number) => void;
 }
 
-export const Carousel = ({ carouselDataInfo, dotsState, viewCount }: CarouselProps) => {
+export const Carousel = ({
+  carouselDataInfo,
+  dotsState,
+  viewCount,
+  handleClick,
+}: CarouselProps) => {
   const settings = {
     dots: dotsState,
     infinite: true,
@@ -34,7 +40,11 @@ export const Carousel = ({ carouselDataInfo, dotsState, viewCount }: CarouselPro
   return (
     <StyledSlider {...settings}>
       {carouselDataInfo?.map((item: Recipe, idx: number) => (
-        <Card sx={{ maxWidth: '100%', height: '450px' }} key={idx}>
+        <Card
+          sx={{ maxWidth: '100%', height: '450px', cursor: 'pointer', userSelect: 'none' }}
+          key={idx}
+          onClick={() => handleClick && handleClick(item.id)}
+        >
           <CardHeader
             avatar={
               <Avatar sx={{ bgcolor: red[500] }} aria-label="recipe">

--- a/src/components/common/Carousel.tsx
+++ b/src/components/common/Carousel.tsx
@@ -7,15 +7,17 @@ import Avatar from '@mui/material/Avatar';
 import Typography from '@mui/material/Typography';
 import { red } from '@mui/material/colors';
 import styled from 'styled-components';
-import { Chip } from '@mui/material';
+import { type Recipe } from '../../types/recipeType';
+import { formatDate } from '../../utils/formatDate';
+import { PiCookingPotDuotone, PiEyeDuotone } from 'react-icons/pi';
 
 interface CarouselProps {
-  carouselImageInfo: string[];
+  carouselDataInfo: Recipe[];
   dotsState: boolean;
   viewCount: number;
 }
 
-export const Carousel = ({ carouselImageInfo, dotsState, viewCount }: CarouselProps) => {
+export const Carousel = ({ carouselDataInfo, dotsState, viewCount }: CarouselProps) => {
   const settings = {
     dots: dotsState,
     infinite: true,
@@ -31,37 +33,36 @@ export const Carousel = ({ carouselImageInfo, dotsState, viewCount }: CarouselPr
 
   return (
     <StyledSlider {...settings}>
-      {carouselImageInfo?.map((item: string) => (
-        <Card sx={{ maxWidth: '100%' }}>
+      {carouselDataInfo?.map((item: Recipe, idx: number) => (
+        <Card sx={{ maxWidth: '100%', height: '450px' }} key={idx}>
           <CardHeader
             avatar={
               <Avatar sx={{ bgcolor: red[500] }} aria-label="recipe">
-                1위
+                <span className="ranking">{idx + 1}위</span>
               </Avatar>
             }
-            title="존맛탱 음식"
-            subheader="띠띠"
+            title={<div className="nickname">{item.author.nickname}</div>}
+            subheader={<div className="date">{formatDate(item.createdAt)}</div>}
           />
-          <CardMedia component="img" height="194" image={item} alt="음식" />
+          <CardMedia component="img" height="194" image={item.imageUrl} alt="음식" />
           <CardContent>
             <Typography variant="body2" color="text.secondary">
-              너무너무 맛있어서 다이어트 실패하는 레시피를 가져왔어요! 너무너무 맛있어서 다이어트
-              실패하는 레시피를 가져왔어요! 너무너무 맛있어서 다이어트 실패하는 레시피를 가져왔어요!
-              너무너무 맛있어서 다이어트 실패하는 레시피를 가져왔어요! 너무너무 맛있어서 다이어트
-              실패하는 레시피를 가져왔어요! 너무너무 맛있어서 다이어트 실패하는 레시피를 가져왔어요!
-              너무너무 맛있어서 다이어트 실패하는 레시피를 가져왔어요! 너무너무 맛있어서 다이어트
-              실패하는 레시피를 가져왔어요! 너무너무 맛있어서 다이어트 실패하는 레시피를 가져왔어요!
-              너무너무 맛있어서 다이어트 실패하는 레시피를 가져왔어요! 너무너무 맛있어서 다이어트
-              실패하는 레시피를 가져왔어요! 너무너무 맛있어서 다이어트 실패하는 레시피를 가져왔어요!
-              너무너무 맛있어서 다이어트 실패하는 레시피를 가져왔어요! 너무너무 맛있어서 다이어트
-              실패하는 레시피를 가져왔어요! 너무너무 맛있어서 다이어트 실패하는 레시피를 가져왔어요!
-              너무너무 맛있어서 다이어트 실패하는 레시피를 가져왔어요!
+              <h5 className="title">{item.title}</h5>
             </Typography>
-            <h5>일치하는 재료</h5>
-            <div className="chips">
-              <Chip label="양파" />
-              <Chip label="마늘" />
-              <Chip label="후추" />
+            <div className="summary">{item.summary}</div>
+            <div className="counts">
+              <span>
+                <span>
+                  <PiEyeDuotone />
+                </span>
+                <span>{item.viewCount}</span>
+              </span>
+              <span>
+                <span>
+                  <PiCookingPotDuotone />
+                </span>
+                <span>{item.reviewCount}</span>
+              </span>
             </div>
           </CardContent>
         </Card>
@@ -81,8 +82,9 @@ const StyledSlider = styled(Slider)`
   }
 
   .slick-slide {
-    display: flex;
-    justify-content: center;
+    display: block;
+    padding: 12px;
+    position: relative;
   }
 
   img {
@@ -101,14 +103,22 @@ const StyledSlider = styled(Slider)`
     font-family: Pretendard-Regular;
   }
 
-  h5 {
+  .title {
     padding: 12px 0;
+    font-size: 16px;
+    color: ${(props) => props.theme.colors.black};
   }
 
-  .chips {
-    display: flex;
-    gap: 6px;
-    margin-bottom: -6px;
+  .summary {
+    font-size: 14px;
+    color: ${(props) => props.theme.colors.darkGray};
+    word-wrap: break-word;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
   }
 
   .slick-prev,
@@ -134,5 +144,37 @@ const StyledSlider = styled(Slider)`
   }
   .slick-dots li.slick-active button {
     background-color: ${(props) => props.theme.colors.gray};
+  }
+
+  .nickname {
+    font-size: 16px;
+    font-family: Pretendard-Bold;
+  }
+
+  .date {
+    font-family: Pretendard-SemiBold;
+  }
+
+  .ranking {
+    font-size: 18px;
+    font-family: Pretendard-SemiBold;
+  }
+
+  .counts {
+    position: absolute;
+    bottom: 30px;
+    right: 30px;
+    display: flex;
+    gap: 12px;
+
+    & > span {
+      display: flex;
+      gap: 4px;
+
+      & > span {
+        display: flex;
+        align-items: center;
+      }
+    }
   }
 `;

--- a/src/components/common/RecipeCard.tsx
+++ b/src/components/common/RecipeCard.tsx
@@ -10,6 +10,7 @@ import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
 
 interface CardProps {
+  recipeId: number;
   recipeTitle: string;
   briefExplanation: string;
   imageURL: string;
@@ -27,6 +28,7 @@ interface State {
 }
 
 export const RecipeCard = ({
+  recipeId,
   recipeTitle,
   briefExplanation,
   imageURL,
@@ -44,7 +46,7 @@ export const RecipeCard = ({
 
   return (
     <StyledCard sx={cardSize}>
-      <Link to="/recipe/1">
+      <Link to={`/recipe/${recipeId}`}>
         <Container $display={display}>
           <CardMedia sx={imgSize} image={imageURL} title="레시피 사진" />
           <div>

--- a/src/components/pages/fridge/IngredientAccordion.tsx
+++ b/src/components/pages/fridge/IngredientAccordion.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import type { Ingredient, IngredientEditList } from '../../../types/ingredientType';
+import type { FridgeIngredient, IngredientEditList } from '../../../types/ingredientType';
 import {
   Accordion,
   AccordionDetails,
@@ -14,7 +14,7 @@ import { BasicButton } from '../../common/BasicButton';
 import { theme } from '../../../styles/theme';
 
 interface IngredientAccordionProps {
-  ingredient: Ingredient;
+  ingredient: FridgeIngredient;
   setDeleteIdList?: React.Dispatch<React.SetStateAction<number[] | null>>;
   setEditList?: React.Dispatch<React.SetStateAction<IngredientEditList[] | null>>;
 }

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -13,4 +13,6 @@ export const QUERY_KEY = {
   SEARCH_INGREIDENT: 'searchIngredient',
   NOTIFICATION: 'notification',
   READ_NOTIC: 'readNotic',
+  GET_LATEST_RECIPE: 'getLatestRecipes',
+  GET_POPULAR_RECIPE: 'getPopularRecipes',
 } as const;

--- a/src/pages/EditIngredient.tsx
+++ b/src/pages/EditIngredient.tsx
@@ -8,7 +8,7 @@ import { useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { QUERY_KEY } from '../constants/queryKey';
 import { getIngredient } from '../api/fridge';
-import type { Ingredient, IngredientEditList } from '../types/ingredientType';
+import type { FridgeIngredient, IngredientEditList } from '../types/ingredientType';
 import { IngredientAccordion } from '../components/pages/fridge/IngredientAccordion';
 import { cookingComplete } from '../api/cook';
 
@@ -54,10 +54,10 @@ export const EditIngredient = () => {
 
   return (
     <>
-      <BasicTitle title="어떤 재료를 사용했나요?" />
+      <BasicTitle title="삭제할 재료를 선택하세요!" />
       <EditIngredientContainer>
         <div className="ingredient-list">
-          {data?.map((ingredient: Ingredient) => {
+          {data?.map((ingredient: FridgeIngredient) => {
             return (
               <IngredientAccordion
                 key={ingredient.name}
@@ -86,7 +86,7 @@ export const EditIngredient = () => {
             $fontcolor={theme.colors.white}
             onClick={() => handleIngredientEdit()}
           >
-            재료 수정
+            냉장고 업데이트
           </BasicButton>
         </div>
       </EditIngredientContainer>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,13 +7,19 @@ import { Carousel } from '../components/common/Carousel';
 import { QUERY_KEY } from '../constants/queryKey';
 import { useQuery } from '@tanstack/react-query';
 import { getPopularRecipes } from '../api/recipe';
+import { useNavigate } from 'react-router-dom';
 
 export const Index = () => {
+  const navigation = useNavigate();
   const { data: popularRecipeData } = useQuery({
     queryKey: [QUERY_KEY.GET_LATEST_RECIPE],
     queryFn: () => getPopularRecipes(5),
     select: (data) => data.data.content,
   });
+
+  const handleClick = (recipeId: number) => {
+    navigation(`/recipe/${recipeId}`);
+  };
 
   return (
     <>
@@ -29,7 +35,12 @@ export const Index = () => {
           <BasicTitle title="인기 레시피" />
           <MoreButton>더보기</MoreButton>
         </Title>
-        <Carousel carouselDataInfo={popularRecipeData} dotsState viewCount={2} />
+        <Carousel
+          carouselDataInfo={popularRecipeData}
+          dotsState
+          viewCount={1}
+          handleClick={handleClick}
+        />
       </IndexContainer>
     </>
   );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,13 +4,16 @@ import { Suspense } from 'react';
 import { CardList } from '../components/common/CardList';
 import { FallBack } from '../components/common/FallBack';
 import { Carousel } from '../components/common/Carousel';
+import { QUERY_KEY } from '../constants/queryKey';
+import { useQuery } from '@tanstack/react-query';
+import { getPopularRecipes } from '../api/recipe';
 
 export const Index = () => {
-  const testImage = [
-    'https://blog.kakaocdn.net/dn/bBeQzv/btq4dw1SNcQ/7b9ROACX8r0oWRUckQKib0/img.png',
-    'https://img.hankyung.com/photo/202108/99.26501439.1-1200x.jpg',
-    'https://d12zq4w4guyljn.cloudfront.net/750_750_20220702061143834_photo_4fceeae73135.jpg',
-  ];
+  const { data: popularRecipeData } = useQuery({
+    queryKey: [QUERY_KEY.GET_LATEST_RECIPE],
+    queryFn: () => getPopularRecipes(5),
+    select: (data) => data.data.content,
+  });
 
   return (
     <>
@@ -26,7 +29,7 @@ export const Index = () => {
           <BasicTitle title="인기 레시피" />
           <MoreButton>더보기</MoreButton>
         </Title>
-        <Carousel carouselImageInfo={testImage} dotsState viewCount={1} />
+        <Carousel carouselDataInfo={popularRecipeData} dotsState viewCount={2} />
       </IndexContainer>
     </>
   );

--- a/src/pages/RecipeView.tsx
+++ b/src/pages/RecipeView.tsx
@@ -16,10 +16,10 @@ import { formatDate } from '../utils/formatDate';
 import { Chip } from '@mui/material';
 import type { Ingredient, RecipeSteps } from '../types/recipeType';
 import { ImageModal } from '../components/common/ImageModal';
-import { RecipeReviewList } from '../components/pages/Recipe/RecipeReviewList';
 import { makeReport } from '../api/report';
 import { BasicInput } from '../components/common/BasicInput';
 import { type AxiosError } from 'axios';
+import { RecipeReviewList } from '../components/pages/recipe/RecipeReviewList';
 
 export const RecipeView = () => {
   const navigation = useNavigate();
@@ -92,7 +92,7 @@ export const RecipeView = () => {
   };
 
   const { data } = useQuery({
-    queryKey: [QUERY_KEY.DETAIL_RECIPE],
+    queryKey: [QUERY_KEY.DETAIL_RECIPE, recipeId],
     queryFn: () => getDetailRecipe(recipeId),
     select: (data) => data.data,
   });

--- a/src/types/recipeType.ts
+++ b/src/types/recipeType.ts
@@ -4,13 +4,14 @@ export interface Member {
 }
 
 export interface Recipe {
-  id: number;
-  title: string;
-  summary: string;
-  recipeImageUrl: string;
-  reviewCount: number;
+  author: DetailRecipe['author'];
   createdAt: string;
-  member: Member;
+  id: number;
+  imageUrl: string;
+  reviewCount: number;
+  summary: string;
+  title: string;
+  viewCount: number;
 }
 
 export interface DetailRecipe {


### PR DESCRIPTION
## 작업 목적
- 메인페이지 데이터 연동

## 작업 내용
- 최신 레시피 데이터 연동
- 인기 레시피 데이터 연동
- 변경된 재료 타입 에러 수정
-  레시피 클릭 시 해당 레시피 뷰 페이지로 라우팅

![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/85798544/60624d9c-bfa6-43fe-8a4b-4e84507a21da)


## 관련된 이슈, 커밋, PR
- #103 