### PR TITLE
냉장고를 부탁해 #108 레시피 작성 페이지 및 레시피 페이지 및 검색 페이지 버그 수정 및 일부 UI 변경

### DIFF
--- a/src/components/common/RecipeCard.tsx
+++ b/src/components/common/RecipeCard.tsx
@@ -88,6 +88,7 @@ const Container = styled.div<State>`
 `;
 
 const StyledCard = styled(Card)`
+  position: relative;
   min-height: 300px;
   margin: 5px;
 
@@ -100,10 +101,15 @@ const StyledCard = styled(Card)`
   }
 `;
 
-const RecipeTitle = styled.h5`
+const RecipeTitle = styled.p`
   font-size: 20px;
   line-height: 30px;
   font-weight: 600;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const BriefExplanation = styled.p`
@@ -111,10 +117,20 @@ const BriefExplanation = styled.p`
   width: 100%;
   margin-top: 20px;
   line-height: 20px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const RecipeInfo = styled.div`
+  position: absolute;
+  width: 100%;
   padding: 10px;
+  max-height: 73px;
+
+  bottom: 0;
 `;
 
 const DateInfo = styled.div`

--- a/src/components/pages/Recipe/RecipeStep.tsx
+++ b/src/components/pages/Recipe/RecipeStep.tsx
@@ -85,6 +85,7 @@ export const RecipeStep = ({
           defaultValue=""
           render={({ field }) => (
             <Content
+              maxLength={200}
               id={`${index}.content`}
               placeholder="레시피의 내용을 입력해 주세요."
               {...field}

--- a/src/components/pages/Recipe/UsedIngrident.tsx
+++ b/src/components/pages/Recipe/UsedIngrident.tsx
@@ -24,6 +24,7 @@ export const UsedIngrident = ({ addItemList, setAddItemList, deleteItem }: Added
           </div>
           <input
             defaultValue={e.id && e.amount}
+            value={e.amount}
             type="text"
             placeholder="재료 양"
             onChange={(event) => setAddItemList(e.name, event.target.value)}

--- a/src/components/pages/fridge/MyIngredientList.tsx
+++ b/src/components/pages/fridge/MyIngredientList.tsx
@@ -26,7 +26,10 @@ export const MyIngredientList = () => {
     onError: () => {
       alert('유효기간을 다시 확인해 주세요!.');
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: [QUERY_KEY.FRIGE_INGREDIENT] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.FRIGE_SEARCH] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.FRIGE_INGREDIENT] });
+    },
   });
 
   const [edit, setEdit] = useState<boolean>(false);

--- a/src/components/pages/fridge/MyIngredientList.tsx
+++ b/src/components/pages/fridge/MyIngredientList.tsx
@@ -87,8 +87,6 @@ export const MyIngredientList = () => {
     setUpdatedItems({});
   };
 
-  console.log(updatedItems);
-
   return (
     <Container>
       <TitleWrapper>
@@ -247,6 +245,7 @@ const MemoInput = styled.input`
 `;
 
 const InfoWrapper = styled.div`
+  min-height: 152px;
   & > span {
     display: block;
     margin-bottom: 2px;

--- a/src/hooks/useCardStyle.ts
+++ b/src/hooks/useCardStyle.ts
@@ -11,7 +11,7 @@ export const useCardStyle = (size: string) => {
       setImgSize({ minWidth: 400, height: 350 });
       setDisplay({ display: 'flex' });
     } else {
-      setCardSize({ maxWidth: 345, minHeight: 300, minWidth: 290 });
+      setCardSize({ maxWidth: 345, minHeight: 415, minWidth: 290 });
       setImgSize({ height: 190 });
     }
   }, [size]);

--- a/src/hooks/useRecipe.ts
+++ b/src/hooks/useRecipe.ts
@@ -22,6 +22,7 @@ export function useRecipe() {
       .map((name) => ({ name, amount: '' }));
 
     setIngredient((prev) => [...(prev || []), ...newIngredients]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [addItemList]);
 
   const setIngridentAmount = (name: string, amount: string) => {

--- a/src/hooks/useRecipe.ts
+++ b/src/hooks/useRecipe.ts
@@ -4,12 +4,14 @@ import { addNewRecipe } from '../api/recipe'; // addNewRecipe API 호출 함수�
 import type { Ingredient } from '../pages/AddRecipe';
 import { useMutation } from '@tanstack/react-query';
 import { useSelectItem } from './useSelectItem';
+import { useNavigate } from 'react-router-dom';
 
 interface StepImg {
   image: File | null;
 }
 
 export function useRecipe() {
+  const navigate = useNavigate();
   const [stepImage, setStepImage] = useState<StepImg[]>([]);
   const [thumbnail, setThumbnail] = useState<File | null>(null);
   const [ingredient, setIngredient] = useState<Ingredient[]>();
@@ -76,9 +78,15 @@ export function useRecipe() {
   const addRecipeMutation = useMutation({
     mutationFn: addNewRecipe,
     onError: (error) => console.log(error),
+    onSuccess: (data) => {
+      // eslint-disable-next-line no-alert
+      alert('레시피를 성공적으로 저장했습니다.');
+      navigate(`/recipe/${data.data.id}`);
+    },
   });
 
   const handleDeleteStep = (index: number) => {
+    deleteImageStep(index);
     setStepImage(stepImage.filter((_, idx) => idx !== index));
   };
 

--- a/src/pages/AddRecipe.tsx
+++ b/src/pages/AddRecipe.tsx
@@ -10,6 +10,7 @@ import { Controller, useForm } from 'react-hook-form';
 import { RecipeStep } from '../components/pages/Recipe/RecipeStep';
 import { UsedIngrident } from '../components/pages/Recipe/UsedIngrident';
 import { useRecipe } from '../hooks/useRecipe';
+import { useNavigate } from 'react-router-dom';
 
 export interface StepImage {
   image: File | null;
@@ -31,6 +32,7 @@ export interface Ingredient {
 }
 
 export const AddRecipe = () => {
+  const navigate = useNavigate();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const {
@@ -49,8 +51,6 @@ export const AddRecipe = () => {
     setAddItemList,
     setStepImage,
   } = useRecipe();
-
-  console.log(ingredient);
 
   const handleAddRecipe = async (data: InputData) => {
     if (thumbnail === null) {
@@ -154,6 +154,7 @@ export const AddRecipe = () => {
         </Thumbnail>
         {stepImage.map((e, index) => (
           <RecipeStep
+            key={index}
             image={e.image}
             index={index}
             control={control}
@@ -171,7 +172,12 @@ export const AddRecipe = () => {
           +
         </BasicButton>
         <ButtonWrapper>
-          <BasicButton type="button" $bgcolor={theme.colors.orange} $fontcolor={theme.colors.white}>
+          <BasicButton
+            type="button"
+            $bgcolor={theme.colors.orange}
+            $fontcolor={theme.colors.white}
+            onClick={() => navigate('/recipe')}
+          >
             돌아가기
           </BasicButton>
           <BasicButton type="submit" $bgcolor={theme.colors.orange} $fontcolor={theme.colors.white}>

--- a/src/pages/AddRecipe.tsx
+++ b/src/pages/AddRecipe.tsx
@@ -50,6 +50,8 @@ export const AddRecipe = () => {
     setStepImage,
   } = useRecipe();
 
+  console.log(ingredient);
+
   const handleAddRecipe = async (data: InputData) => {
     if (thumbnail === null) {
       // eslint-disable-next-line no-alert

--- a/src/pages/MyRefrigerator.tsx
+++ b/src/pages/MyRefrigerator.tsx
@@ -36,7 +36,10 @@ export const MyRefrigerator = () => {
 
   const addIngridentMutation = useMutation({
     mutationFn: addIngredient,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: [QUERY_KEY.FRIGE_INGREDIENT] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.FRIGE_SEARCH] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.FRIGE_INGREDIENT] });
+    },
     onError: (error: AxiosError) => {
       const { data } = error.response?.data as ErrorType;
       // eslint-disable-next-line no-alert

--- a/src/pages/Recipe.tsx
+++ b/src/pages/Recipe.tsx
@@ -4,12 +4,36 @@ import { BasicButton } from '../components/common/BasicButton';
 import { theme } from '../styles/theme';
 import { useNavigate } from 'react-router-dom';
 import { RecipeCard } from '../components/common/RecipeCard';
+import InfiniteScroll from 'react-infinite-scroll-component';
+import { ACCESS_TOKEN_KEY } from '../constants/api';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getFrigeKeyWordSearch } from '../api/search';
+import { QUERY_KEY } from '../constants/queryKey';
+import type { SearchKeyWord } from '../types/searchResultType';
+import { device } from '../styles/media';
 
 export const Recipe = () => {
+  const isLogIn = !!sessionStorage.getItem(ACCESS_TOKEN_KEY);
+
   const navigation = useNavigate();
   const handleRecipePost = () => {
     navigation('/add');
   };
+
+  const frigeKeyWord = useInfiniteQuery({
+    queryKey: [QUERY_KEY.FRIGE_SEARCH],
+    queryFn: ({ pageParam = 1 }) => getFrigeKeyWordSearch(pageParam),
+    getNextPageParam: (_, allPages) => allPages.length,
+    initialPageParam: 0,
+    enabled: isLogIn,
+  });
+
+  const fridgeContent = frigeKeyWord.data
+    ? frigeKeyWord.data.pages.flatMap((page) => page.data.content)
+    : [];
+
+  const fridgeDataLength = fridgeContent.length;
+
   return (
     <RecipeContainer>
       <div className="header">
@@ -29,6 +53,7 @@ export const Recipe = () => {
       <BasicTitle title="최신 레시피" />
       <CardList>
         <RecipeCard
+          recipeId={1}
           recipeTitle="레시피 제목"
           briefExplanation="간단 설명 You can add ornaments to the beginning of the component."
           imageURL="https://img.freepik.com/free-photo/cheesy-tokbokki-korean-traditional-food-on-black-board-background-lunch-dish_1150-42986.jpg?size=626&ext=jpg&ga=GA1.1.1546980028.1703376000&semt=ais"
@@ -39,6 +64,7 @@ export const Recipe = () => {
           size="small"
         />
         <RecipeCard
+          recipeId={1}
           recipeTitle="레시피 제목"
           briefExplanation="간단 설명 You can add ornaments to the beginning of the component."
           imageURL="https://img.freepik.com/free-photo/cheesy-tokbokki-korean-traditional-food-on-black-board-background-lunch-dish_1150-42986.jpg?size=626&ext=jpg&ga=GA1.1.1546980028.1703376000&semt=ais"
@@ -49,6 +75,7 @@ export const Recipe = () => {
           size="small"
         />
         <RecipeCard
+          recipeId={1}
           recipeTitle="레시피 제목"
           briefExplanation="간단 설명 You can add ornaments to the beginning of the component."
           imageURL="https://img.freepik.com/free-photo/cheesy-tokbokki-korean-traditional-food-on-black-board-background-lunch-dish_1150-42986.jpg?size=626&ext=jpg&ga=GA1.1.1546980028.1703376000&semt=ais"
@@ -59,6 +86,7 @@ export const Recipe = () => {
           size="small"
         />
         <RecipeCard
+          recipeId={1}
           recipeTitle="레시피 제목"
           briefExplanation="간단 설명 You can add ornaments to the beginning of the component."
           imageURL="https://img.freepik.com/free-photo/cheesy-tokbokki-korean-traditional-food-on-black-board-background-lunch-dish_1150-42986.jpg?size=626&ext=jpg&ga=GA1.1.1546980028.1703376000&semt=ais"
@@ -70,48 +98,55 @@ export const Recipe = () => {
         />
       </CardList>
       <BasicTitle title="당신을 위한 추천 레시피" />
-      <CardList>
-        <RecipeCard
-          recipeTitle="레시피 제목"
-          briefExplanation="간단 설명 You can add ornaments to the beginning of the component."
-          imageURL="https://img.freepik.com/free-photo/cheesy-tokbokki-korean-traditional-food-on-black-board-background-lunch-dish_1150-42986.jpg?size=626&ext=jpg&ga=GA1.1.1546980028.1703376000&semt=ais"
-          date="2020-04-14"
-          reviewCount={10}
-          auther="나에요"
-          viewCount={117}
-          size="small"
-        />
-        <RecipeCard
-          recipeTitle="레시피 제목"
-          briefExplanation="간단 설명 You can add ornaments to the beginning of the component."
-          imageURL="https://img.freepik.com/free-photo/cheesy-tokbokki-korean-traditional-food-on-black-board-background-lunch-dish_1150-42986.jpg?size=626&ext=jpg&ga=GA1.1.1546980028.1703376000&semt=ais"
-          date="2020-04-14"
-          reviewCount={10}
-          auther="나에요"
-          viewCount={117}
-          size="small"
-        />
-        <RecipeCard
-          recipeTitle="레시피 제목"
-          briefExplanation="간단 설명 You can add ornaments to the beginning of the component."
-          imageURL="https://img.freepik.com/free-photo/cheesy-tokbokki-korean-traditional-food-on-black-board-background-lunch-dish_1150-42986.jpg?size=626&ext=jpg&ga=GA1.1.1546980028.1703376000&semt=ais"
-          date="2020-04-14"
-          reviewCount={10}
-          auther="나에요"
-          viewCount={117}
-          size="small"
-        />
-        <RecipeCard
-          recipeTitle="레시피 제목"
-          briefExplanation="간단 설명 You can add ornaments to the beginning of the component."
-          imageURL="https://img.freepik.com/free-photo/cheesy-tokbokki-korean-traditional-food-on-black-board-background-lunch-dish_1150-42986.jpg?size=626&ext=jpg&ga=GA1.1.1546980028.1703376000&semt=ais"
-          date="2020-04-14"
-          reviewCount={10}
-          auther="나에요"
-          viewCount={117}
-          size="small"
-        />
-      </CardList>
+      {isLogIn ? (
+        <>
+          {fridgeDataLength !== 0 ? (
+            <Wrapper>
+              <InfiniteScroll
+                dataLength={fridgeDataLength}
+                next={frigeKeyWord.fetchNextPage}
+                hasMore={frigeKeyWord.hasNextPage || false}
+                loader={null}
+              >
+                <FrigeSearch>
+                  {fridgeContent.map((item: SearchKeyWord) => (
+                    <RecipeCard
+                      recipeId={item.id}
+                      recipeTitle={item.title}
+                      briefExplanation={item.summary}
+                      imageURL={item.imageUrl}
+                      date={item.createdAt}
+                      reviewCount={item.reviewCount}
+                      auther={item.author.nickname}
+                      viewCount={item.viewCount}
+                      size="small"
+                    ></RecipeCard>
+                  ))}
+                </FrigeSearch>
+              </InfiniteScroll>
+            </Wrapper>
+          ) : (
+            <Info>
+              <p>재료를 먼저 등록해 주세요!</p>
+
+              <BasicButton
+                type="button"
+                $bgcolor={theme.colors.orange}
+                $fontcolor={theme.colors.white}
+                onClick={() => navigation('/refrigerator')}
+              >
+                등록하러 가기
+              </BasicButton>
+            </Info>
+          )}
+        </>
+      ) : (
+        <Wrapper>
+          <Info>
+            <p>로그인 하면 나만의 재료로 만들 수 있는 레시피를 알 수 있어요!</p>
+          </Info>
+        </Wrapper>
+      )}
     </RecipeContainer>
   );
 };
@@ -143,4 +178,32 @@ const CardList = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
   margin-bottom: 48px;
+`;
+
+const FrigeSearch = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+
+  @media ${device.mobile} {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const Wrapper = styled.div`
+  margin-top: 45px;
+`;
+
+const Info = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  height: 200px;
+  color: ${(props) => props.theme.colors.darkGray};
+  font-size: 20px;
+
+  button {
+    margin-top: 25px;
+    max-width: 160px;
+  }
 `;

--- a/src/pages/SearchResult.tsx
+++ b/src/pages/SearchResult.tsx
@@ -75,6 +75,7 @@ export const SearchResult = () => {
                     .flatMap((page) => page.data.content)
                     .map((item) => (
                       <RecipeCard
+                        recipeId={item.id}
                         recipeTitle={item.title}
                         briefExplanation={item.summary}
                         imageURL={item.imageUrl}
@@ -114,6 +115,7 @@ export const SearchResult = () => {
                 .flatMap((page) => page.data.content)
                 .map((item: SearchKeyWord) => (
                   <RecipeCard
+                    recipeId={item.id}
                     recipeTitle={item.title}
                     briefExplanation={item.summary}
                     imageURL={item.imageUrl}


### PR DESCRIPTION
## 작업내용
![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/107461545/8b7b1b91-096f-4e0c-836c-d7237ce302a2)
레시피 작성 페이지
- 재료 밀리는 버그 수정
- 200자 이상 작성 못하게 막음
- 완료 시 해당 레시피 뷰 페이지로 이동하도록 라우팅 처리
- 돌아가기 버튼 활성화
레시피 페이지 당신을 위한 레시피 추천
- 무한스크롤로 구현
- 로그인 하지 않으면 보이지 않음
- 로그인을 했더라도 재료가 없다면 리스트가 보이지 않음
검색페이지
- 기존 당신을 위한 레시피 추천을 삭제