### PR TITLE
냉장고를부탁해 #110 레시피 페이지, 마이페이지 구현 및 버그 수정

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -21,3 +21,13 @@ export const getBookmarkedRecipe = async (page: number) => {
   const result = await axiosAuth.get(`${END_POINTS.BOOKMARK}?page=${page}`);
   return result.data;
 };
+
+export const getMyRecipes = async (size: number, page = 0) => {
+  const result = await axiosAuth.get(`${END_POINTS.MEMBER_RECIPE}?page=${page}&size=${size}`);
+  return result.data;
+};
+
+export const getCompletedCooking = async (size: number, page = 0) => {
+  const result = await axiosAuth.get(`${END_POINTS.MEMBER_COOK}?page=${page}&size=${size}`);
+  return result.data;
+};

--- a/src/api/recipe.ts
+++ b/src/api/recipe.ts
@@ -72,3 +72,8 @@ export const getPopularRecipes = async (size: number, page = 0) => {
   const result = await axiosDefault.get(`${END_POINTS.RECIPES}/popular?page=${page}&size=${size}`);
   return result.data;
 };
+
+export const getRecipesCount = async () => {
+  const result = await axiosDefault.get(`${END_POINTS.RECIPES}`);
+  return result.data;
+};

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -88,14 +88,14 @@ export const Header = () => {
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
         ></SearchInput>
-        {userNickName && (
+        {userNickName !== '' && (
           <Nickname>
             <StyledLink to="/mypage">
               <span>{`${userNickName}님`}</span>
             </StyledLink>
           </Nickname>
         )}
-        {authState ? (
+        {userNickName !== '' ? (
           <>
             <BasicButton
               onClick={handleLogOut}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -25,7 +25,7 @@ export const Header = () => {
 
   const setCurrentCategory = useSetRecoilState(currentCategoryAtom);
   const [userNickName, setUserNickName] = useRecoilState(NickNameAtom);
-  const [authState, setAuthState] = useRecoilState(AuthStateAtom);
+  const setAuthState = useSetRecoilState(AuthStateAtom);
   const [isLogOut, setIsLogOut] = useState(false);
   const [leftNotic, setLeftNotic] = useState([]);
 

--- a/src/components/pages/Recipe/LatestRecipe.tsx
+++ b/src/components/pages/Recipe/LatestRecipe.tsx
@@ -9,7 +9,7 @@ import { type Recipe } from '../../../types/recipeType';
 
 export const LatestRecipe = () => {
   const { data, fetchNextPage, hasNextPage } = useInfiniteQuery({
-    queryKey: [QUERY_KEY.GET_LATEST_RECIPE],
+    queryKey: [QUERY_KEY.GET_LATEST_RECIPE_INFINITE],
     queryFn: ({ pageParam }) => getLatestRecipes(6, pageParam),
     initialPageParam: 0,
     getNextPageParam: (_, allPages) => {
@@ -24,7 +24,7 @@ export const LatestRecipe = () => {
         next={fetchNextPage}
         hasMore={!!hasNextPage}
         loader={null}
-        dataLength={data ? data.pages.flatMap((page) => page.data.content).length : 0}
+        dataLength={data ? data.pages?.flatMap((page) => page.data.content).length : 0}
       >
         <CardList>
           {data?.pages

--- a/src/components/pages/Recipe/LatestRecipe.tsx
+++ b/src/components/pages/Recipe/LatestRecipe.tsx
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+import { BasicTitle } from '../../common/BasicTitle';
+import { RecipeCard } from '../../common/RecipeCard';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '../../../constants/queryKey';
+import { getLatestRecipes } from '../../../api/recipe';
+import InfiniteScroll from 'react-infinite-scroll-component';
+import { type Recipe } from '../../../types/recipeType';
+
+export const LatestRecipe = () => {
+  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery({
+    queryKey: [QUERY_KEY.GET_LATEST_RECIPE],
+    queryFn: ({ pageParam }) => getLatestRecipes(6, pageParam),
+    initialPageParam: 0,
+    getNextPageParam: (_, allPages) => {
+      return allPages.length;
+    },
+  });
+
+  return (
+    <>
+      <BasicTitle title="최신 레시피" />
+      <InfiniteScroll
+        next={fetchNextPage}
+        hasMore={!!hasNextPage}
+        loader={null}
+        dataLength={data ? data.pages.flatMap((page) => page.data.content).length : 0}
+      >
+        <CardList>
+          {data?.pages
+            .flatMap((page) => page.data.content)
+            .map((info: Recipe) => (
+              <RecipeCard
+                recipeId={info.id}
+                key={info.id}
+                recipeTitle={info.title}
+                briefExplanation={info.summary}
+                imageURL={info.imageUrl}
+                date={info.createdAt}
+                reviewCount={info.reviewCount}
+                auther={info.author.nickname}
+                viewCount={info.viewCount}
+                size="small"
+              />
+            ))}
+        </CardList>
+      </InfiniteScroll>
+    </>
+  );
+};
+
+const CardList = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin-bottom: 48px;
+`;

--- a/src/components/pages/Recipe/PopularRecipe.tsx
+++ b/src/components/pages/Recipe/PopularRecipe.tsx
@@ -9,7 +9,7 @@ import { type Recipe } from '../../../types/recipeType';
 
 export const PopularRecipe = () => {
   const { data, fetchNextPage, hasNextPage } = useInfiniteQuery({
-    queryKey: [QUERY_KEY.GET_POPULAR_RECIPE],
+    queryKey: [QUERY_KEY.GET_POPULAR_RECIPE_INFINITE],
     queryFn: ({ pageParam }) => getPopularRecipes(6, pageParam),
     initialPageParam: 0,
     getNextPageParam: (_, allPages) => {
@@ -24,7 +24,7 @@ export const PopularRecipe = () => {
         next={fetchNextPage}
         hasMore={!!hasNextPage}
         loader={null}
-        dataLength={data ? data.pages.flatMap((page) => page.data.content).length : 0}
+        dataLength={data ? data.pages?.flatMap((page) => page.data.content).length : 0}
       >
         <CardList>
           {data?.pages

--- a/src/components/pages/Recipe/PopularRecipe.tsx
+++ b/src/components/pages/Recipe/PopularRecipe.tsx
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+import { BasicTitle } from '../../common/BasicTitle';
+import { RecipeCard } from '../../common/RecipeCard';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '../../../constants/queryKey';
+import { getPopularRecipes } from '../../../api/recipe';
+import InfiniteScroll from 'react-infinite-scroll-component';
+import { type Recipe } from '../../../types/recipeType';
+
+export const PopularRecipe = () => {
+  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery({
+    queryKey: [QUERY_KEY.GET_POPULAR_RECIPE],
+    queryFn: ({ pageParam }) => getPopularRecipes(6, pageParam),
+    initialPageParam: 0,
+    getNextPageParam: (_, allPages) => {
+      return allPages.length;
+    },
+  });
+
+  return (
+    <>
+      <BasicTitle title="인기 레시피" />
+      <InfiniteScroll
+        next={fetchNextPage}
+        hasMore={!!hasNextPage}
+        loader={null}
+        dataLength={data ? data.pages.flatMap((page) => page.data.content).length : 0}
+      >
+        <CardList>
+          {data?.pages
+            .flatMap((page) => page.data.content)
+            .map((info: Recipe, idx) => (
+              <RecipeCard
+                recipeId={info.id}
+                key={idx}
+                recipeTitle={info.title}
+                briefExplanation={info.summary}
+                imageURL={info.imageUrl}
+                date={info.createdAt}
+                reviewCount={info.reviewCount}
+                auther={info.author.nickname}
+                viewCount={info.viewCount}
+                size="small"
+              />
+            ))}
+        </CardList>
+      </InfiniteScroll>
+    </>
+  );
+};
+
+const CardList = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin-bottom: 48px;
+`;

--- a/src/components/pages/Recipe/RecipeReview.tsx
+++ b/src/components/pages/Recipe/RecipeReview.tsx
@@ -30,10 +30,14 @@ export const RecipeReview = ({ reviewData }: { reviewData: Review }) => {
   const queryClient = useQueryClient();
   const mutation = useMutation({
     mutationFn: () => reviewDelete(reviewData.id),
-    onSuccess: () =>
+    onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.GET_REVIEW],
-      }),
+      });
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEY.DETAIL_RECIPE],
+      });
+    },
   });
 
   const handleDelete = () => {

--- a/src/components/pages/Recipe/RecipeReviewList.tsx
+++ b/src/components/pages/Recipe/RecipeReviewList.tsx
@@ -12,7 +12,7 @@ export const RecipeReviewList = () => {
   const { pathname } = useLocation();
   const recipeId = pathname.split('/').pop() || '';
 
-  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery({
+  const { data, isSuccess, refetch, fetchNextPage, hasNextPage } = useInfiniteQuery({
     queryKey: [QUERY_KEY.GET_REVIEW, recipeId],
     queryFn: ({ pageParam }) => getReviews(recipeId, pageParam as number),
     initialPageParam: 0,
@@ -20,6 +20,8 @@ export const RecipeReviewList = () => {
       return allPages.length;
     },
   });
+
+  if (isSuccess) refetch();
 
   return (
     <RecipeReviewListContainer>

--- a/src/components/pages/Recipe/RecipeReviewList.tsx
+++ b/src/components/pages/Recipe/RecipeReviewList.tsx
@@ -13,7 +13,7 @@ export const RecipeReviewList = () => {
   const recipeId = pathname.split('/').pop() || '';
 
   const { data, fetchNextPage, hasNextPage } = useInfiniteQuery({
-    queryKey: [QUERY_KEY.GET_REVIEW],
+    queryKey: [QUERY_KEY.GET_REVIEW, recipeId],
     queryFn: ({ pageParam }) => getReviews(recipeId, pageParam as number),
     initialPageParam: 0,
     getNextPageParam: (_, allPages) => {

--- a/src/components/pages/Recipe/RecommendedRecipe.tsx
+++ b/src/components/pages/Recipe/RecommendedRecipe.tsx
@@ -79,7 +79,7 @@ export const RecommendedRecipe = () => {
       ) : (
         <Wrapper>
           <Info>
-            <p>로그인 하면 나만의 재료로 만들 수 있는 레시피를 알 수 있어요!</p>
+            <p>로그인 후 나만의 재료로 만들 수 있는 레시피를 볼 수 있어요!</p>
           </Info>
         </Wrapper>
       )}

--- a/src/components/pages/Recipe/RecommendedRecipe.tsx
+++ b/src/components/pages/Recipe/RecommendedRecipe.tsx
@@ -1,0 +1,116 @@
+import InfiniteScroll from 'react-infinite-scroll-component';
+import { type SearchKeyWord } from '../../../types/searchResultType';
+import { useNavigate } from 'react-router';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '../../../constants/queryKey';
+import { getFrigeKeyWordSearch } from '../../../api/search';
+import { BasicButton } from '../../common/BasicButton';
+import styled from 'styled-components';
+import { device } from '../../../styles/media';
+import { ACCESS_TOKEN_KEY } from '../../../constants/api';
+import { RecipeCard } from '../../common/RecipeCard';
+import { theme } from '../../../styles/theme';
+import { BasicTitle } from '../../common/BasicTitle';
+
+export const RecommendedRecipe = () => {
+  const isLogIn = !!sessionStorage.getItem(ACCESS_TOKEN_KEY);
+
+  const navigation = useNavigate();
+
+  const frigeKeyWord = useInfiniteQuery({
+    queryKey: [QUERY_KEY.FRIGE_SEARCH],
+    queryFn: ({ pageParam = 1 }) => getFrigeKeyWordSearch(pageParam),
+    getNextPageParam: (_, allPages) => allPages.length,
+    initialPageParam: 0,
+    enabled: isLogIn,
+  });
+
+  const fridgeContent = frigeKeyWord.data
+    ? frigeKeyWord.data.pages.flatMap((page) => page.data.content)
+    : [];
+
+  const fridgeDataLength = fridgeContent.length;
+  return (
+    <>
+      <BasicTitle title="당신을 위한 추천 레시피" />
+      {isLogIn ? (
+        <>
+          {fridgeDataLength !== 0 ? (
+            <Wrapper>
+              <InfiniteScroll
+                dataLength={fridgeDataLength}
+                next={frigeKeyWord.fetchNextPage}
+                hasMore={frigeKeyWord.hasNextPage || false}
+                loader={null}
+              >
+                <FrigeSearch>
+                  {fridgeContent.map((item: SearchKeyWord) => (
+                    <RecipeCard
+                      key={item.id}
+                      recipeId={item.id}
+                      recipeTitle={item.title}
+                      briefExplanation={item.summary}
+                      imageURL={item.imageUrl}
+                      date={item.createdAt}
+                      reviewCount={item.reviewCount}
+                      auther={item.author.nickname}
+                      viewCount={item.viewCount}
+                      size="small"
+                    ></RecipeCard>
+                  ))}
+                </FrigeSearch>
+              </InfiniteScroll>
+            </Wrapper>
+          ) : (
+            <Info>
+              <p>재료를 먼저 등록해 주세요!</p>
+
+              <BasicButton
+                type="button"
+                $bgcolor={theme.colors.orange}
+                $fontcolor={theme.colors.white}
+                onClick={() => navigation('/refrigerator')}
+              >
+                등록하러 가기
+              </BasicButton>
+            </Info>
+          )}
+        </>
+      ) : (
+        <Wrapper>
+          <Info>
+            <p>로그인 하면 나만의 재료로 만들 수 있는 레시피를 알 수 있어요!</p>
+          </Info>
+        </Wrapper>
+      )}
+    </>
+  );
+};
+
+const FrigeSearch = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+
+  @media ${device.mobile} {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const Wrapper = styled.div`
+  margin-top: 45px;
+`;
+
+const Info = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  height: 200px;
+  color: ${(props) => props.theme.colors.darkGray};
+  font-size: 20px;
+
+  button {
+    margin-top: 25px;
+    max-width: 160px;
+  }
+`;

--- a/src/components/pages/myPage/CompletedCooking.tsx
+++ b/src/components/pages/myPage/CompletedCooking.tsx
@@ -43,6 +43,8 @@ export const CompletedCooking = () => {
             ))}
         </CardList>
       </InfiniteScroll>
+
+      {!data && <NoRecipe>완료한 요리가 없어요!</NoRecipe>}
     </>
   );
 };
@@ -51,4 +53,10 @@ const CardList = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
   margin-bottom: 48px;
+`;
+
+const NoRecipe = styled.div`
+  margin: -48px auto;
+  font-size: 18px;
+  text-align: center;
 `;

--- a/src/components/pages/myPage/CompletedCooking.tsx
+++ b/src/components/pages/myPage/CompletedCooking.tsx
@@ -1,0 +1,54 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getCompletedCooking } from '../../../api/member';
+import { QUERY_KEY } from '../../../constants/queryKey';
+import InfiniteScroll from 'react-infinite-scroll-component';
+import { type CompletedDish } from '../../../types/recipeType';
+import { RecipeCard } from '../../common/RecipeCard';
+import styled from 'styled-components';
+
+export const CompletedCooking = () => {
+  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery({
+    queryKey: [QUERY_KEY.GET_COMPLETED_COOKING],
+    queryFn: ({ pageParam }) => getCompletedCooking(6, pageParam),
+    initialPageParam: 0,
+    getNextPageParam: (_, allPages) => {
+      return allPages.length;
+    },
+  });
+
+  return (
+    <>
+      <InfiniteScroll
+        next={fetchNextPage}
+        hasMore={!!hasNextPage}
+        loader={null}
+        dataLength={data ? data.pages?.flatMap((page) => page.data.content).length : 0}
+      >
+        <CardList>
+          {data?.pages
+            .flatMap((page) => page.data.content)
+            .map((info: CompletedDish) => (
+              <RecipeCard
+                recipeId={info?.id}
+                key={info?.id}
+                recipeTitle={info?.recipeInfoDto.title}
+                briefExplanation={info?.recipeInfoDto.summary}
+                imageURL={info?.recipeInfoDto.imageUrl}
+                date={info?.recipeInfoDto.createdAt}
+                reviewCount={info?.recipeInfoDto.reviewCount}
+                auther={info?.recipeInfoDto.author.nickname}
+                viewCount={info?.recipeInfoDto.viewCount}
+                size="small"
+              />
+            ))}
+        </CardList>
+      </InfiniteScroll>
+    </>
+  );
+};
+
+const CardList = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin-bottom: 48px;
+`;

--- a/src/components/pages/myPage/EmailAuth.tsx
+++ b/src/components/pages/myPage/EmailAuth.tsx
@@ -6,19 +6,11 @@ import { BasicButton } from '../../common/BasicButton';
 import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { emailAuthInMyPage } from '../../../api/auth';
-import { axiosAuth } from '../../../api/axiosInstance';
-import {
-  ACCESS_TOKEN_KEY,
-  END_POINTS,
-  USER_NICKNAME_KEY,
-  USER_STATUS_KEY,
-} from '../../../constants/api';
+import { ACCESS_TOKEN_KEY, USER_STATUS_KEY } from '../../../constants/api';
 import type { AxiosError } from 'axios';
-import { useNavigate } from 'react-router-dom';
 
 export const EmailAuth = () => {
   const [authCode, setAuthCode] = useState<string | undefined>('');
-  const navigation = useNavigate();
 
   const { mutate } = useMutation({
     mutationFn: emailAuthInMyPage,
@@ -46,18 +38,6 @@ export const EmailAuth = () => {
     setAuthCode('');
   };
 
-  const leave = async () => {
-    const { data } = await axiosAuth.delete(END_POINTS.LEAVE);
-    console.log(data);
-
-    sessionStorage.removeItem(ACCESS_TOKEN_KEY);
-    sessionStorage.removeItem(USER_STATUS_KEY);
-    sessionStorage.removeItem(USER_NICKNAME_KEY);
-
-    document.cookie = `refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
-    navigation('/');
-  };
-
   return (
     <NicknameEditContainer>
       <BasicInput
@@ -71,9 +51,6 @@ export const EmailAuth = () => {
       <BasicButton onClick={handleSendAuthCode} $bgcolor="#ff8527" type="text" $fontcolor="#fff">
         인증 확인
       </BasicButton>
-      <button type="button" onClick={leave}>
-        탈퇴
-      </button>
     </NicknameEditContainer>
   );
 };

--- a/src/components/pages/myPage/MyCooking.tsx
+++ b/src/components/pages/myPage/MyCooking.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import ButtonGroup from '@mui/material/ButtonGroup';
+import { MYCOOKING_CATEGORIES } from '../../../constants/menu';
+import styled from 'styled-components';
+import { MyRecipe } from './MyRecipe';
+import { CompletedCooking } from './CompletedCooking';
+
+export const MyCooking = () => {
+  const [selectedCategory, setSelectedCategory] = useState('내가 등록한 레시피');
+
+  return (
+    <section>
+      <MyCookingCategory>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            '& > *': {
+              m: 1,
+            },
+          }}
+        >
+          <ButtonGroup size="small" aria-label="small button group">
+            {MYCOOKING_CATEGORIES.map((button) => (
+              <Button
+                key={button}
+                onClick={() => setSelectedCategory(button)}
+                className={selectedCategory === button ? 'is--active' : ''}
+              >
+                {button}
+              </Button>
+            ))}
+          </ButtonGroup>
+        </Box>
+      </MyCookingCategory>
+      <div>{selectedCategory === '내가 등록한 레시피' ? <MyRecipe /> : <CompletedCooking />}</div>
+    </section>
+  );
+};
+
+const MyCookingCategory = styled.div`
+  margin-bottom: 24px;
+  .is--active {
+    background-color: ${(props) => props.theme.colors.sky}40;
+  }
+`;

--- a/src/components/pages/myPage/MyRecipe.tsx
+++ b/src/components/pages/myPage/MyRecipe.tsx
@@ -45,6 +45,8 @@ export const MyRecipe = () => {
             })}
         </CardList>
       </InfiniteScroll>
+
+      {!data && <NoRecipe>내가 등록한 레시피가 없어요!</NoRecipe>}
     </>
   );
 };
@@ -53,4 +55,10 @@ const CardList = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
   margin-bottom: 48px;
+`;
+
+const NoRecipe = styled.div`
+  margin: -48px auto;
+  font-size: 18px;
+  text-align: center;
 `;

--- a/src/components/pages/myPage/MyRecipe.tsx
+++ b/src/components/pages/myPage/MyRecipe.tsx
@@ -1,0 +1,56 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getMyRecipes } from '../../../api/member';
+import { QUERY_KEY } from '../../../constants/queryKey';
+import InfiniteScroll from 'react-infinite-scroll-component';
+import { type Recipe } from '../../../types/recipeType';
+import { RecipeCard } from '../../common/RecipeCard';
+import styled from 'styled-components';
+
+export const MyRecipe = () => {
+  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery({
+    queryKey: [QUERY_KEY.GET_MY_RECIPE],
+    queryFn: ({ pageParam }) => getMyRecipes(6, pageParam),
+    initialPageParam: 0,
+    getNextPageParam: (_, allPages) => {
+      return allPages.length;
+    },
+  });
+
+  return (
+    <>
+      <InfiniteScroll
+        next={fetchNextPage}
+        hasMore={!!hasNextPage}
+        loader={null}
+        dataLength={data ? data.pages?.flatMap((page) => page.data.content).length : 0}
+      >
+        <CardList>
+          {data?.pages
+            .flatMap((page) => page.data.content)
+            .map((info: Recipe) => {
+              return (
+                <RecipeCard
+                  recipeId={info?.id}
+                  key={info?.id}
+                  recipeTitle={info?.title}
+                  briefExplanation={info?.summary}
+                  imageURL={info?.imageUrl}
+                  date={info?.createdAt}
+                  reviewCount={info?.reviewCount}
+                  auther={info?.author.nickname}
+                  viewCount={info?.viewCount}
+                  size="small"
+                />
+              );
+            })}
+        </CardList>
+      </InfiniteScroll>
+    </>
+  );
+};
+
+const CardList = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin-bottom: 48px;
+`;

--- a/src/constants/menu.ts
+++ b/src/constants/menu.ts
@@ -4,7 +4,7 @@ export const MYPAGE_MENU = [
   '비밀번호 변경',
   '이메일 인증',
   '나의 요리',
-  '로그아웃',
+  '회원 탈퇴',
 ] as const;
 
 export const RECIPE_CATEGORIES = ['최신 레시피', '인기 레시피', '추천 레시피'] as const;

--- a/src/constants/menu.ts
+++ b/src/constants/menu.ts
@@ -8,3 +8,4 @@ export const MYPAGE_MENU = [
 ] as const;
 
 export const RECIPE_CATEGORIES = ['최신 레시피', '인기 레시피', '추천 레시피'] as const;
+export const MYCOOKING_CATEGORIES = ['내가 등록한 레시피', '완료한 요리'] as const;

--- a/src/constants/menu.ts
+++ b/src/constants/menu.ts
@@ -6,3 +6,5 @@ export const MYPAGE_MENU = [
   '나의 요리',
   '로그아웃',
 ] as const;
+
+export const RECIPE_CATEGORIES = ['최신 레시피', '인기 레시피', '추천 레시피'] as const;

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -1,5 +1,6 @@
 // 이곳에 쿼리키 정의
 export const QUERY_KEY = {
+  RECIPES_COUNT: 'recipesCount',
   NEW_RECIPE: 'newRecipe',
   DETAIL_RECIPE: 'detailRecipe',
   FRIGE_INGREDIENT: 'frigeIngredient',

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -15,7 +15,9 @@ export const QUERY_KEY = {
   NOTIFICATION: 'notification',
   READ_NOTIC: 'readNotic',
   GET_LATEST_RECIPE: 'getLatestRecipes',
+  GET_LATEST_RECIPE_INFINITE: 'getLatestRecipes_infinite',
   GET_POPULAR_RECIPE: 'getPopularRecipes',
+  GET_POPULAR_RECIPE_INFINITE: 'getPopularRecipes_infinite',
   INGREDIENT_SEARCH: 'ingredientSearch',
   FRIGE_SEARCH: 'firgeSearch',
 } as const;

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -20,4 +20,6 @@ export const QUERY_KEY = {
   GET_POPULAR_RECIPE_INFINITE: 'getPopularRecipes_infinite',
   INGREDIENT_SEARCH: 'ingredientSearch',
   FRIGE_SEARCH: 'firgeSearch',
+  GET_MY_RECIPE: 'getMyRecipes',
+  GET_COMPLETED_COOKING: 'getCompletedCooking',
 } as const;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,7 +12,7 @@ import { useNavigate } from 'react-router-dom';
 export const Index = () => {
   const navigation = useNavigate();
   const { data: popularRecipeData } = useQuery({
-    queryKey: [QUERY_KEY.GET_LATEST_RECIPE],
+    queryKey: [QUERY_KEY.GET_POPULAR_RECIPE],
     queryFn: () => getPopularRecipes(5),
     select: (data) => data.data.content,
   });

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -10,11 +10,14 @@ import { MyCooking } from '../components/pages/myPage/MyCooking';
 import { useNavigate } from 'react-router';
 import { END_POINTS } from '../constants/api';
 import { axiosAuth } from '../api/axiosInstance';
+import { useSetRecoilState } from 'recoil';
+import { NickNameAtom } from '../store/auth';
 
 export const MyPage = () => {
   const navigation = useNavigate();
   const [logoutModal, setLogoutModal] = useState(false);
   const [selectedMenu, setSelectedMenu] = useState<(typeof MYPAGE_MENU)[number]>(MYPAGE_MENU[0]);
+  const setUser = useSetRecoilState(NickNameAtom);
 
   const handleMenu = (menu: (typeof MYPAGE_MENU)[number]) => {
     setSelectedMenu(menu);
@@ -25,6 +28,7 @@ export const MyPage = () => {
 
   const leave = async () => {
     await axiosAuth.delete(END_POINTS.LEAVE);
+    setUser('');
     sessionStorage.clear();
     document.cookie = `refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
     navigation('/');

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -6,6 +6,7 @@ import { PasswordEdit } from '../components/pages/myPage/PasswordEdit';
 import { PushList } from '../components/pages/myPage/PushList';
 import { ConfirmModal } from '../components/common/ConfirmModal';
 import { EmailAuth } from '../components/pages/myPage/EmailAuth';
+import { MyCooking } from '../components/pages/myPage/MyCooking';
 
 export const MyPage = () => {
   const [logoutModal, setLogoutModal] = useState(false);
@@ -28,6 +29,8 @@ export const MyPage = () => {
         return <PasswordEdit />;
       case '이메일 인증':
         return <EmailAuth />;
+      case '나의 요리':
+        return <MyCooking />;
       default:
         return null;
     }

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -7,16 +7,27 @@ import { PushList } from '../components/pages/myPage/PushList';
 import { ConfirmModal } from '../components/common/ConfirmModal';
 import { EmailAuth } from '../components/pages/myPage/EmailAuth';
 import { MyCooking } from '../components/pages/myPage/MyCooking';
+import { useNavigate } from 'react-router';
+import { END_POINTS } from '../constants/api';
+import { axiosAuth } from '../api/axiosInstance';
 
 export const MyPage = () => {
+  const navigation = useNavigate();
   const [logoutModal, setLogoutModal] = useState(false);
   const [selectedMenu, setSelectedMenu] = useState<(typeof MYPAGE_MENU)[number]>(MYPAGE_MENU[0]);
 
   const handleMenu = (menu: (typeof MYPAGE_MENU)[number]) => {
     setSelectedMenu(menu);
-    if (menu === '로그아웃') {
+    if (menu === '회원 탈퇴') {
       setLogoutModal(true);
     }
+  };
+
+  const leave = async () => {
+    await axiosAuth.delete(END_POINTS.LEAVE);
+    sessionStorage.clear();
+    document.cookie = `refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+    navigation('/');
   };
 
   const renderSelectedComponent = () => {
@@ -53,14 +64,15 @@ export const MyPage = () => {
             );
           })}
         </MyPageMenu>
-        <h2>{selectedMenu !== '로그아웃' && selectedMenu}</h2>
+        <h2>{selectedMenu !== '회원 탈퇴' && selectedMenu}</h2>
         {renderSelectedComponent()}
         {logoutModal && (
           <ConfirmModal
             handleOpen={setLogoutModal}
             isOpen={logoutModal}
-            title="로그아웃 할까요?"
-            description="메인페이지로 돌아갑니다."
+            title="정말 탈퇴할까요?"
+            description="동일 계정으로 재가입이 불가합니다."
+            onAgree={leave}
           />
         )}
       </MyPageContainer>

--- a/src/pages/Recipe.tsx
+++ b/src/pages/Recipe.tsx
@@ -1,44 +1,40 @@
+/* eslint-disable no-nested-ternary */
 import styled from 'styled-components';
-import { BasicTitle } from '../components/common/BasicTitle';
-import { BasicButton } from '../components/common/BasicButton';
 import { theme } from '../styles/theme';
-import { useNavigate } from 'react-router-dom';
-import { RecipeCard } from '../components/common/RecipeCard';
-import InfiniteScroll from 'react-infinite-scroll-component';
-import { ACCESS_TOKEN_KEY } from '../constants/api';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { getFrigeKeyWordSearch } from '../api/search';
+import { BasicButton } from '../components/common/BasicButton';
+import { useNavigate } from 'react-router';
+import { RecommendedRecipe } from '../components/pages/recipe/RecommendedRecipe';
+import { LatestRecipe } from '../components/pages/recipe/LatestRecipe';
+import { useQuery } from '@tanstack/react-query';
 import { QUERY_KEY } from '../constants/queryKey';
-import type { SearchKeyWord } from '../types/searchResultType';
-import { device } from '../styles/media';
+import { getRecipesCount } from '../api/recipe';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import ButtonGroup from '@mui/material/ButtonGroup';
+import { useState } from 'react';
+import { RECIPE_CATEGORIES } from '../constants/menu';
+import { PopularRecipe } from '../components/pages/recipe/PopularRecipe';
 
 export const Recipe = () => {
-  const isLogIn = !!sessionStorage.getItem(ACCESS_TOKEN_KEY);
-
   const navigation = useNavigate();
+  const [selectedCategory, setSelectedCategory] = useState('최신 레시피');
+
   const handleRecipePost = () => {
     navigation('/add');
   };
 
-  const frigeKeyWord = useInfiniteQuery({
-    queryKey: [QUERY_KEY.FRIGE_SEARCH],
-    queryFn: ({ pageParam = 1 }) => getFrigeKeyWordSearch(pageParam),
-    getNextPageParam: (_, allPages) => allPages.length,
-    initialPageParam: 0,
-    enabled: isLogIn,
+  const { data: count } = useQuery({
+    queryKey: [QUERY_KEY.RECIPES_COUNT],
+    queryFn: getRecipesCount,
+    select: (data) => data.data,
   });
-
-  const fridgeContent = frigeKeyWord.data
-    ? frigeKeyWord.data.pages.flatMap((page) => page.data.content)
-    : [];
-
-  const fridgeDataLength = fridgeContent.length;
 
   return (
     <RecipeContainer>
       <div className="header">
         <p>
-          총 <span className="recipe-count">13,435개</span>의 맛있는 레시피가 있어요!
+          총 <span className="recipe-count">{Number(count).toLocaleString('ko-KR')}개</span>의
+          맛있는 레시피가 있어요!
         </p>
         <BasicButton
           type="submit"
@@ -50,103 +46,42 @@ export const Recipe = () => {
           레시피 등록
         </BasicButton>
       </div>
-      <BasicTitle title="최신 레시피" />
-      <CardList>
-        <RecipeCard
-          recipeId={1}
-          recipeTitle="레시피 제목"
-          briefExplanation="간단 설명 You can add ornaments to the beginning of the component."
-          imageURL="https://img.freepik.com/free-photo/cheesy-tokbokki-korean-traditional-food-on-black-board-background-lunch-dish_1150-42986.jpg?size=626&ext=jpg&ga=GA1.1.1546980028.1703376000&semt=ais"
-          date="2020-04-14"
-          reviewCount={10}
-          auther="나에요"
-          viewCount={117}
-          size="small"
-        />
-        <RecipeCard
-          recipeId={1}
-          recipeTitle="레시피 제목"
-          briefExplanation="간단 설명 You can add ornaments to the beginning of the component."
-          imageURL="https://img.freepik.com/free-photo/cheesy-tokbokki-korean-traditional-food-on-black-board-background-lunch-dish_1150-42986.jpg?size=626&ext=jpg&ga=GA1.1.1546980028.1703376000&semt=ais"
-          date="2020-04-14"
-          reviewCount={10}
-          auther="나에요"
-          viewCount={117}
-          size="small"
-        />
-        <RecipeCard
-          recipeId={1}
-          recipeTitle="레시피 제목"
-          briefExplanation="간단 설명 You can add ornaments to the beginning of the component."
-          imageURL="https://img.freepik.com/free-photo/cheesy-tokbokki-korean-traditional-food-on-black-board-background-lunch-dish_1150-42986.jpg?size=626&ext=jpg&ga=GA1.1.1546980028.1703376000&semt=ais"
-          date="2020-04-14"
-          reviewCount={10}
-          auther="나에요"
-          viewCount={117}
-          size="small"
-        />
-        <RecipeCard
-          recipeId={1}
-          recipeTitle="레시피 제목"
-          briefExplanation="간단 설명 You can add ornaments to the beginning of the component."
-          imageURL="https://img.freepik.com/free-photo/cheesy-tokbokki-korean-traditional-food-on-black-board-background-lunch-dish_1150-42986.jpg?size=626&ext=jpg&ga=GA1.1.1546980028.1703376000&semt=ais"
-          date="2020-04-14"
-          reviewCount={10}
-          auther="나에요"
-          viewCount={117}
-          size="small"
-        />
-      </CardList>
-      <BasicTitle title="당신을 위한 추천 레시피" />
-      {isLogIn ? (
-        <>
-          {fridgeDataLength !== 0 ? (
-            <Wrapper>
-              <InfiniteScroll
-                dataLength={fridgeDataLength}
-                next={frigeKeyWord.fetchNextPage}
-                hasMore={frigeKeyWord.hasNextPage || false}
-                loader={null}
+      <RecipeCategory>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            '& > *': {
+              m: 1,
+            },
+          }}
+        >
+          <ButtonGroup size="large" aria-label="large button group">
+            {RECIPE_CATEGORIES.map((button) => (
+              <Button
+                key={button}
+                onClick={() => setSelectedCategory(button)}
+                className={selectedCategory === button ? 'is--active' : ''}
               >
-                <FrigeSearch>
-                  {fridgeContent.map((item: SearchKeyWord) => (
-                    <RecipeCard
-                      recipeId={item.id}
-                      recipeTitle={item.title}
-                      briefExplanation={item.summary}
-                      imageURL={item.imageUrl}
-                      date={item.createdAt}
-                      reviewCount={item.reviewCount}
-                      auther={item.author.nickname}
-                      viewCount={item.viewCount}
-                      size="small"
-                    ></RecipeCard>
-                  ))}
-                </FrigeSearch>
-              </InfiniteScroll>
-            </Wrapper>
-          ) : (
-            <Info>
-              <p>재료를 먼저 등록해 주세요!</p>
+                {button}
+              </Button>
+            ))}
+          </ButtonGroup>
+        </Box>
+      </RecipeCategory>
 
-              <BasicButton
-                type="button"
-                $bgcolor={theme.colors.orange}
-                $fontcolor={theme.colors.white}
-                onClick={() => navigation('/refrigerator')}
-              >
-                등록하러 가기
-              </BasicButton>
-            </Info>
-          )}
-        </>
-      ) : (
-        <Wrapper>
-          <Info>
-            <p>로그인 하면 나만의 재료로 만들 수 있는 레시피를 알 수 있어요!</p>
-          </Info>
-        </Wrapper>
-      )}
+      <div>
+        {selectedCategory === '최신 레시피' ? (
+          <LatestRecipe />
+        ) : selectedCategory === '인기 레시피' ? (
+          <PopularRecipe />
+        ) : selectedCategory === '추천 레시피' ? (
+          <RecommendedRecipe />
+        ) : (
+          <LatestRecipe />
+        )}
+      </div>
     </RecipeContainer>
   );
 };
@@ -174,36 +109,10 @@ const RecipeContainer = styled.div`
   }
 `;
 
-const CardList = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  margin-bottom: 48px;
-`;
+const RecipeCategory = styled.div`
+  padding: 24px 0 48px 0;
 
-const FrigeSearch = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-
-  @media ${device.mobile} {
-    grid-template-columns: 1fr;
-  }
-`;
-
-const Wrapper = styled.div`
-  margin-top: 45px;
-`;
-
-const Info = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-direction: column;
-  height: 200px;
-  color: ${(props) => props.theme.colors.darkGray};
-  font-size: 20px;
-
-  button {
-    margin-top: 25px;
-    max-width: 160px;
+  .is--active {
+    background-color: ${(props) => props.theme.colors.sky}40;
   }
 `;

--- a/src/pages/ReviewPost.tsx
+++ b/src/pages/ReviewPost.tsx
@@ -30,6 +30,9 @@ export const ReviewPost = () => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.GET_REVIEW],
       });
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEY.DETAIL_RECIPE],
+      });
       navigation(`/recipe/${recipeId}`);
     },
   });

--- a/src/types/recipeType.ts
+++ b/src/types/recipeType.ts
@@ -14,6 +14,11 @@ export interface Recipe {
   viewCount: number;
 }
 
+export interface CompletedDish {
+  id: number;
+  recipeInfoDto: Recipe;
+}
+
 export interface DetailRecipe {
   author: {
     id: number;


### PR DESCRIPTION

## 작업 목적
- 레시피 페이지 완성
- 마이페이지 완성 (알림 제외)

## 작업 내용
- 레시피 페이지
  - 전체 레시피 개수 표시
  - 카테고리 생성 (최신 레시피/인기 레시피/추천 레시피)
  - 각 카테고리마다 무한스크롤로 데이터 fetching

![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/85798544/d8c44726-a559-48a0-8348-9a864fa3f13c)

---


- 마이페이지 - 나의 요리 
  - 카테고리 생성 (내가 등록한 레시피/완료한 요리)
  - 각 카테고리마다 무한스크롤로 데이터 fetching

![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/85798544/086723d7-e2de-43ea-ac77-5b490454e3ab)

---


- 마이페이지 - 회원 탈퇴 
  - 로그아웃 버튼 회원 탈퇴 기능으로 수정
  - header 로그인 상태 분기처리 버그 수정

![image](https://github.com/fridge-rescue/fridge-rescue-client/assets/85798544/34fad0ab-b406-4190-8822-8d4b05d682a8)


## 관련된 이슈, 커밋, PR
- #110 
- #41 
- #18 